### PR TITLE
[MOD-113][Fix] Fix date on moderation list page

### DIFF
--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -1,4 +1,25 @@
 import Ember from 'ember';
+import moment from 'moment';
+
+const PENDING = 'pending';
+const ACCEPTED = 'accepted';
+const REJECTED = 'rejected';
+
+const ACTION_LABELS = Object.freeze({
+    [PENDING]: {
+        gtDay: 'components.moderation-list-row.submission.submitted_on',
+        ltDay: 'components.moderation-list-row.submission.submitted',
+    },
+    [ACCEPTED]: {
+        gtDay: 'components.moderation-list-row.submission.was_accepted_on',
+        ltDay: 'components.moderation-list-row.submission.was_accepted',
+    },
+    [REJECTED]: {
+        gtDay: 'components.moderation-list-row.submission.was_rejected_on',
+        ltDay: 'components.moderation-list-row.submission.was_rejected',
+    }
+});
+
 
 export default Ember.Component.extend({
     theme: Ember.inject.service(),
@@ -11,7 +32,25 @@ export default Ember.Component.extend({
         rejected: 'fa-times-circle-o rejected'
     },
 
+    gtDay: Ember.computed('submission.dateLastTransitioned', function() {
+        return moment().diff(this.get('submission.dateLastTransitioned'), 'days') > 1;
+    }),
+
+    relevantDate: Ember.computed('submission.dateLastTransitioned', 'gtDay', function() {
+        return this.get('gtDay') ?
+            moment(this.get('submission.dateLastTransitioned')).format('MMMM DD, YYYY') :
+            moment(this.get('submission.dateLastTransitioned')).fromNow();
+    }),
+
     //translations
-    submittedOnLabel: 'components.moderation-list-row.submission.submitted_on',
-    submittedByLabel: 'components.moderation-list-row.submission.by',
+    dateLabel: Ember.computed('submission.reviewsState', 'gtDay', function() {
+        const dayValue = this.get('gtDay') ? 'gtDay' : 'ltDay';
+        return ACTION_LABELS[this.get('submission.reviewsState')][dayValue];
+    }),
+
+    submittedByLabel: Ember.computed('submission.reviewsState', function() {
+        return this.get('submission.reviewsState') === PENDING ?
+            'components.moderation-list-row.submission.by' :
+            'components.moderation-list-row.submission.submission_by';
+    }),
 });

--- a/app/components/moderation-list-row/template.hbs
+++ b/app/components/moderation-list-row/template.hbs
@@ -11,7 +11,11 @@
                 </div>
             {{else}}
                 <div class="submission-body">
-                    {{t submittedOnLabel}} {{moment-format record.dateCreated "MMMM DD, YYYY"}} {{t submittedByLabel}}
+                    {{#if (eq submission.reviewsState 'pending')}}
+                        {{t dateLabel}} {{relevantDate}} {{t submittedByLabel}}
+                    {{else}}
+                        {{t submittedByLabel}}
+                    {{/if}}
                     {{#each submission.node.contributors as |contributor index| ~}}
                         {{#if (lt index 3)}}
                             <li>{{contributor.users.fullName}}</li>
@@ -19,6 +23,9 @@
                             + {{decrement-value submission.node.contributors.length 3}}
                         {{/if}}
                     {{/each}}
+                    {{#if (not-eq submission.reviewsState 'pending')}}
+                        {{t dateLabel}} {{relevantDate}}
+                    {{/if}}
                 </div>
             {{/if}}
         </div>

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -184,13 +184,18 @@ export default {
             accepted: `Accepted`,
             rejected: `Rejected`,
             sort: `Sort`,
-
             no_submissions: `No submissions.`,
         },
         'moderation-list-row': {
             submission: {
                 submitted_on: `submitted on`,
-                by: `by`
+                was_accepted_on: `was accepted on`,
+                was_rejected_on: `was rejected on`,
+                submitted: `submitted`,
+                was_accepted: `was accepted`,
+                was_rejected: `was rejected`,
+                by: `by`,
+                submission_by: `submission by`,
             },
         },
         'preprint-status-banner': {


### PR DESCRIPTION
## Purpose
All dates on the moderation list page were the current date due to a rename mistake.

## Changes
* less than a day show relative time
* update wording on accepted and rejected page to be more relevant

![screen shot 2017-09-29 at 11 42 05 am](https://user-images.githubusercontent.com/7131985/31023967-83833926-a50b-11e7-9c2c-5b1ccfe39422.png)
![screen shot 2017-09-29 at 11 42 23 am](https://user-images.githubusercontent.com/7131985/31023965-83812208-a50b-11e7-99bf-c79c1f35d5d7.png)
