### PR TITLE
[MOD-114][Fix] Show breadcrumb separator in Firefox

### DIFF
--- a/app/components/reviews-breadcrumbs/style.scss
+++ b/app/components/reviews-breadcrumbs/style.scss
@@ -6,9 +6,16 @@ a {
   font-weight: bolder;
 }
 
+// for not firefox
 .separator {
   content: url('img/separator.png');
   vertical-align: middle;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding: 0px 5px 2px 5px;
+}
+
+// for firefox https://stackoverflow.com/questions/17907833/content-url-does-not-display-image-on-firefox-browser
+.separator::after {
+  content: url('img/separator.png');
+  vertical-align: middle;
+  padding: 0px 5px 2px 5px;
 }


### PR DESCRIPTION
## Purpose
![screen shot 2017-09-29 at 12 21 57 pm](https://user-images.githubusercontent.com/7131985/31031333-36abb5a4-a526-11e7-888d-58448c993350.png)

## Changes
* add another css class so that the separator will show up in [Firefox](https://stackoverflow.com/questions/17907833/content-url-does-not-display-image-on-firefox-browser)