### PR TITLE
[Feature][MOD-111] Add preprint" button direct to the current provider's add page

### DIFF
--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -23,7 +23,7 @@ export default Ember.Service.extend({
         return `${config.OSF.url}register?${query}`;
     }),
 
-    pathPrefix: Ember.computed('isProvider', 'domain', 'id', function() {
+    addPreprintUrl: Ember.computed('isProvider', 'domain', 'id', function() {
         let pathPrefix = '/';
 
         if (!this.get('domain')) {

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -23,18 +23,18 @@ export default Ember.Service.extend({
         return `${config.OSF.url}register?${query}`;
     }),
 
-    addPreprintUrl: Ember.computed('isProvider', 'domain', 'id', function() {
-        let pathPrefix = '/';
+    baseServiceUrl: Ember.computed('isProvider', 'domain', 'id', function() {
+        let baseURL = '/';
 
         if (!this.get('domain')) {
-            pathPrefix += 'preprints/';
+            baseURL += 'preprints/';
             if (this.get('provider.id')) {
-                pathPrefix += `${this.get('provider.id')}/`;
+                baseURL += `${this.get('provider.id')}/`;
             }
         } else {
-            pathPrefix = this.get('domain')
+            baseURL = this.get('domain')
         }
-        return pathPrefix;
+        return baseURL;
     }),
 
     onProviderLoad: Ember.observer('provider', function() {

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -14,8 +14,6 @@ export default Ember.Service.extend({
     isProvider: Ember.computed.not('isNotProvider'),
     isNotProvider: Ember.computed.equal('provider.id', 'OSF'),
 
-    isDomain: window.isProviderDomain,
-
     signupUrl: Ember.computed('id', function() {
         const query = Ember.$.param({
             campaign: `${this.get('id')}-reviews`,
@@ -33,7 +31,7 @@ export default Ember.Service.extend({
             if (this.get('provider.id')) {
                 pathPrefix += `${this.get('provider.id')}/`;
             }
-        }else {
+        } else {
             pathPrefix = this.get('domain')
         }
         return pathPrefix;

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -9,9 +9,12 @@ export default Ember.Service.extend({
     provider: null,
 
     id: Ember.computed.alias('provider.id'),
+    domain: Ember.computed.alias('provider.domain'),
     isLoaded: Ember.computed.empty('provider'),
     isProvider: Ember.computed.not('isNotProvider'),
     isNotProvider: Ember.computed.equal('provider.id', 'OSF'),
+
+    isDomain: window.isProviderDomain,
 
     signupUrl: Ember.computed('id', function() {
         const query = Ember.$.param({
@@ -22,9 +25,22 @@ export default Ember.Service.extend({
         return `${config.OSF.url}register?${query}`;
     }),
 
+    pathPrefix: Ember.computed('isProvider', 'domain', 'id', function() {
+        let pathPrefix = '/';
+
+        if (!this.get('domain')) {
+            pathPrefix += 'preprints/';
+            if (this.get('provider.id')) {
+                pathPrefix += `${this.get('provider.id')}/`;
+            }
+        }else {
+            pathPrefix = this.get('domain')
+        }
+        return pathPrefix;
+    }),
+
     onProviderLoad: Ember.observer('provider', function() {
         const locale = Ember.getOwner(this).factoryFor(`locale:${this.get('i18n.locale')}/translations`).class;
-
         this.get('i18n').addGlobals({
             provider: {
                 id: this.get('provider.id'),

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login') addPreprintUrl=theme.addPreprintUrl}}
+{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login') baseServiceUrl=theme.baseServiceUrl}}
 {{maintenance-banner}}
 {{outlet}}
 {{osf-footer}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login') pathPrefix=theme.pathPrefix}}
+{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login') addPreprintUrl=theme.pathPrefix}}
 {{maintenance-banner}}
 {{outlet}}
 {{osf-footer}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login') addPreprintUrl=theme.pathPrefix}}
+{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login') addPreprintUrl=theme.addPreprintUrl}}
 {{maintenance-banner}}
 {{outlet}}
 {{osf-footer}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login')}}
+{{new-osf-navbar hostAppName='Preprints' signupUrl=theme.signupUrl loginAction=(action 'login') pathPrefix=theme.pathPrefix}}
 {{maintenance-banner}}
 {{outlet}}
 {{osf-footer}}


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/MOD-111

This PR should be merged after the other [PR](https://github.com/aaxelb/ember-osf/pull/10) on ember-osf.
# Purpose
"Add preprint" button should take the reviewer to the submit page for the current provider.
If on the dashboard, the OSF preprint submit page.

# Summary of changes
Update theme services to calculate pathPrefix and then pass to new-osf-navbar.

# Testing notes