### PR TITLE
[Fix][MOD-120] Update wording generated/returned by moment.js

### DIFF
--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -44,10 +44,20 @@ export default Ember.Component.extend({
         return moment().diff(this.get('submission.dateLastTransitioned'), 'days') > 1;
     }),
 
+    fewSeconds: Ember.computed('submission.dateLastTransitioned', function() {
+        const timeDiff = Math.abs(moment().diff(this.get('submission.dateLastTransitioned')));
+        if (timeDiff < 70000) { // 70000 milliseconds
+            return 'a few seconds ago';
+        } else {
+            return moment(this.get('submission.dateLastTransitioned')).fromNow();
+        }
+    }),
+
+
     relevantDate: Ember.computed('submission.dateLastTransitioned', 'gtDay', function() {
         return this.get('gtDay') ?
             moment(this.get('submission.dateLastTransitioned')).format('MMMM DD, YYYY') :
-            moment(this.get('submission.dateLastTransitioned')).fromNow();
+            this.get('fewSeconds');
     }),
 
     //translations

--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -44,20 +44,10 @@ export default Ember.Component.extend({
         return moment().diff(this.get('submission.dateLastTransitioned'), 'days') > 1;
     }),
 
-    fewSeconds: Ember.computed('submission.dateLastTransitioned', function() {
-        const timeDiff = Math.abs(moment().diff(this.get('submission.dateLastTransitioned')));
-        if (timeDiff < 70000) { // 70000 milliseconds
-            return 'a few seconds ago';
-        } else {
-            return moment(this.get('submission.dateLastTransitioned')).fromNow();
-        }
-    }),
-
-
     relevantDate: Ember.computed('submission.dateLastTransitioned', 'gtDay', function() {
         return this.get('gtDay') ?
             moment(this.get('submission.dateLastTransitioned')).format('MMMM DD, YYYY') :
-            this.get('fewSeconds');
+            moment(Math.min(Date.parse(this.get('submission.dateLastTransitioned')), Date.now())).fromNow();
     }),
 
     //translations


### PR DESCRIPTION
## Problem 
On transition after a preprint submission, preprints would be listed as modified "a few seconds ago", however sometimes it shows in "a few seconds" or "a minute ago". It seems that there is a time difference between client/server.

## Solution
Calculate the absolute time difference within a slack period of 70000 milliseconds to accommodate the time difference between client/server.

![Alt Text](http://g.recordit.co/aN0Bl1cWQo.gif)

🐼 
## Ticket
https://openscience.atlassian.net/browse/MOD-120