### PR TITLE
[Fix][MOD-124] Fix username link to profile 

### DIFF
--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -126,7 +126,7 @@ export default Ember.Component.extend({
             action.get('creator').then(user => {
                 this.set('creatorName', user.get('fullName'));
                 this.set('creatorProfile', user.get('profileURL'));
-            })
+            });
 
             if (this.get('submission.reviewsState') !== PENDING) {
                 this.set('initialReviewerComment', action.get('comment'));

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -10,7 +10,7 @@
             </span>
         </div>
         <div class="recent-activity">
-            <a href={{profileURL}}>{{creatorName}}</a> {{t recentActivityLanguage}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
+            <a href={{creatorProfile}}>{{creatorName}}</a> {{t recentActivityLanguage}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
         </div>
         <div class="dropdown reviewer-feedback">
             {{#bs-dropdown closeOnMenuClick=false as |dd|}}


### PR DESCRIPTION
## Problem
When a preprint moderator views a preprint, they see a banner reading "<user> submitted this preprint" or "<user> rejected this preprint," etc. The usernames in the banners are clickable links. However, when clicking them, nothing happens. The expected is that clicking the usernames would redirect to that user's profile page.

## Fix
![alt text](http://g.recordit.co/cpoE2I5MUk.gif)

## Ticket
https://openscience.atlassian.net/browse/MOD-124

