### PR TITLE
[MOD-125][Fix] Force reload moderation list query

### DIFF
--- a/app/routes/preprints/provider/moderation.js
+++ b/app/routes/preprints/provider/moderation.js
@@ -18,12 +18,13 @@ export default Ember.Route.extend({
 
     model(params) {
         const provider = this.modelFor('preprints.provider');
+        // Pass `true` to force reloading (added in cos-forks/ember-data-has-many-query)
         return provider.query('preprints', {
             'filter[reviews_state]': params.status,
             'meta[reviews_state_counts]': true,
             sort: params.sort,
             page: params.page
-        }).then((results) => {
+        }, true).then((results) => {
             return {
                 submissions: results.toArray(),
                 totalPages: results.get('meta.total'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@centerforopenscience/ember-osf@https://github.com/aaxelb/ember-osf#feature/reviews":
   version "0.10.2"
-  resolved "https://github.com/aaxelb/ember-osf#56680df3650a2162cc38f6b329ce90504ad48f21"
+  resolved "https://github.com/aaxelb/ember-osf#6a1a03a11d45d60ab5f8ddc70d743434edfd845d"
   dependencies:
     bootstrap-sass "^3.3.7"
     broccoli-funnel "1.2.0"
@@ -3003,15 +3003,9 @@ ember-cookies@^0.0.13:
     ember-cli-babel "^5.1.7"
     ember-getowner-polyfill "^1.2.2"
 
-ember-data-has-many-query@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-data-has-many-query/-/ember-data-has-many-query-0.2.0.tgz#97ae2c29d6d7f77d3837cca9f165c26bf6e6fb0a"
-  dependencies:
-    ember-cli-babel "^5.1.6"
-
 "ember-data-has-many-query@https://github.com/cos-forks/ember-data-has-many-query#master":
   version "0.2.0"
-  resolved "https://github.com/cos-forks/ember-data-has-many-query#7e41ea918af97d174526f9468dd29a47ad0eff5c"
+  resolved "https://github.com/cos-forks/ember-data-has-many-query#cc586f54606d167dc53e3f85d131231d572d9745"
   dependencies:
     ember-cli-babel "^5.1.6"
 


### PR DESCRIPTION
Uses a [slightly modified](https://github.com/cos-forks/ember-data-has-many-query/commit/cc586f54606d167dc53e3f85d131231d572d9745) version of the `ember-data-has-many-query` addon which allows manually forcing a reload.