### PR TITLE
[Improvement] After setup go to settings page

### DIFF
--- a/app/components/moderation-base/component.js
+++ b/app/components/moderation-base/component.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
                 nameKey: 'global.moderation',
                 route: 'preprints.provider.moderation',
                 hasCount: true,
-                count: this.get('pendingCount'),
+                count: this.get('pendingCount') || 0,
             },
             {
                 nameKey: 'global.settings',

--- a/app/controllers/preprints/provider/setup.js
+++ b/app/controllers/preprints/provider/setup.js
@@ -64,7 +64,7 @@ export default Ember.Controller.extend({
                     this.get('i18n').t('setup.error.title').toString()
                 );
             }).then(() => {
-                return this.transitionToRoute('preprints.provider', this.get('model'));
+                return this.transitionToRoute('preprints.provider.settings', this.get('model'));
             });
         }
     }


### PR DESCRIPTION
## Purpose
Once a user has set up their provider it should take them to the settings page. When this occurs pending count isn't defined yet so catch that.