### PR TITLE
[MOD-110][Fix] Hide/exclude preprints with private nodes

### DIFF
--- a/app/routes/preprints/provider/moderation.js
+++ b/app/routes/preprints/provider/moderation.js
@@ -21,7 +21,10 @@ export default Route.extend({
     model(params) {
         const provider = this.modelFor('preprints.provider');
         return this.get('store').queryHasMany(provider, 'preprints', {
-            'filter[reviews_state]': params.status,
+            filter: {
+                reviews_state: params.status,
+                node_is_public: true,
+            },
             'meta[reviews_state_counts]': true,
             sort: params.sort,
             page: params.page,

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -12,6 +12,13 @@ export default Route.extend({
         return this.store.findRecord('preprint', params.preprint_id, { include: ['node', 'license', 'actions'] });
     },
 
+    afterModel(model) {
+        if (!model.get('node.public')) {
+            return this.transitionTo('page-not-found');
+        }
+        return this._super(...arguments);
+    },
+
     setupController() {
         scheduleOnce('afterRender', this, function() {
             if (!MathJax) return;


### PR DESCRIPTION
- Exclude preprints with private nodes from the moderation list.
- Show "Page not found" error when navigating to the detail page of a preprint with a private node.

Depends on CenterForOpenScience/osf.io#7793

https://openscience.atlassian.net/browse/MOD-110