### PR TITLE
[MOD-129][Fix] Remove unnecessary warning for private preprints

### DIFF
--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -24,11 +24,6 @@
                         {{t "content.orphan_preprint"}}
                     </div>
                 {{else}}
-                    {{#if (not node.public)}}
-                        <div class="alert alert-danger m-r-md" role="alert">
-                            {{t "content.private_preprint_warning"}} <a href={{node.links.html}}>{{node.title}} </a> {{t "content.public"}}.
-                        </div>
-                    {{/if}}
                     {{preprint-file-browser primaryFile=model.primaryFile preprint=model chooseFile=(action 'chooseFile')}}
                     <button class="expand-mfr-carrot hidden-xs hidden-sm" {{action 'expandMFR'}}>
                         <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>


### PR DESCRIPTION
After MOD-110, the detail page will redirect to "Page not found" for preprints with private nodes, so this is unnecessary.