### PR TITLE
[MOD-148][Fix] Wait for node before checking node.public

### DIFF
--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -13,10 +13,7 @@ export default Route.extend({
     },
 
     afterModel(model) {
-        if (!model.get('node.public')) {
-            return this.transitionTo('page-not-found');
-        }
-        return this._super(...arguments);
+        return model.get('node').then(this._checkNodePublic.bind(this));
     },
 
     setupController() {
@@ -44,5 +41,11 @@ export default Route.extend({
                 return this.intermediateTransitionTo('page-not-found');
             }
         },
+    },
+
+    _checkNodePublic(node) {
+        if (!node.get('public')) {
+            this.transitionTo('page-not-found');
+        }
     },
 });


### PR DESCRIPTION
When transitioning to the detail page, make sure the node is loaded before checking whether it's public.