### PR TITLE
[MOD-145][Fix] Polyfill so IE doesn't break

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -91,6 +91,9 @@ module.exports = function(defaults) {
                 }],
             },
         },
+        'ember-cli-babel': {
+            includePolyfill: true,
+        },
     });
 
     // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
## Purpose
Many of the pages don't work in IE because `includes` isn't supported. Can't test if including polyfill will fix it until it's on staging. Preprints includes polyfill for phantom tests.