### PR TITLE
[MOD-144][Fix] Standards-compliant breadcrumbs

### DIFF
--- a/app/components/reviews-breadcrumbs/style.scss
+++ b/app/components/reviews-breadcrumbs/style.scss
@@ -6,16 +6,11 @@ a {
   font-weight: bolder;
 }
 
-// for not firefox
 .separator {
-  content: url('img/separator.png');
+  background: url('img/separator.png') no-repeat;
+  display: inline-block;
   vertical-align: middle;
-  padding: 0px 5px 2px 5px;
-}
-
-// for firefox https://stackoverflow.com/questions/17907833/content-url-does-not-display-image-on-firefox-browser
-.separator::after {
-  content: url('img/separator.png');
-  vertical-align: middle;
-  padding: 0px 5px 2px 5px;
+  height: 13px;
+  width: 6px;
+  margin: 0px 5px;
 }

--- a/app/components/reviews-breadcrumbs/template.hbs
+++ b/app/components/reviews-breadcrumbs/template.hbs
@@ -5,6 +5,6 @@
         {{#link-to breadcrumb.path}}
             {{breadcrumb.name}}
         {{/link-to}}
-        <img class="separator">
+        <span class="separator"></span>
     {{/if}}
 {{/each}}


### PR DESCRIPTION
Use `background` instead of `content` to show the breadcrumb icon, for cross-browser compatible goodness.