### PR TITLE
[MOD-163][Fix] Don't disable the default for radio buttons

### DIFF
--- a/app/components/form-block-radiobutton/component.js
+++ b/app/components/form-block-radiobutton/component.js
@@ -19,7 +19,9 @@ export default Component.extend({
 
     click(event) {
         this.set('attribute', this.get('value'));
-        event.preventDefault();
-        return false;
+        if (event.target.type !== 'radio') {
+            event.preventDefault();
+            return false;
+        }
     },
 });


### PR DESCRIPTION
## Purpose
The setup form would not work if you click on the actual circle for the radio buttons instead of the whole block.

## Changes
Don't prevent the default for radio buttons.