### PR TITLE
[Fix] Fix see more and loading-indicator

### DIFF
--- a/app/components/action-feed-entry/template.hbs
+++ b/app/components/action-feed-entry/template.hbs
@@ -15,9 +15,13 @@
             {{/if}}
         </div>
         <div class="action-detail">
-            {{#link-to 'preprints.provider.preprint-detail' action.provider action.target}}
-                {{action.target.title}}
-            {{/link-to}}
+            {{#if action.target.isPending}}
+                {{loading-indicator classes='ball-dark'}}
+            {{else}}
+                {{#link-to 'preprints.provider.preprint-detail' action.provider action.target}}
+                    {{action.target.title}}
+                {{/link-to}}
+            {{/if}}
         </div>
     </div>
 </div>

--- a/app/components/action-feed/component.js
+++ b/app/components/action-feed/component.js
@@ -23,7 +23,7 @@ export default Component.extend({
     errorMessage: t('components.action-feed.error_loading'),
 
     moreActions: computed('totalPages', 'page', 'loadingMore', function() {
-        return this.get('loadingMore') ?  false : this.get('page') < this.get('totalPages');
+        return this.get('loadingMore') ? false : this.get('page') < this.get('totalPages');
     }),
 
     init() {

--- a/app/components/action-feed/component.js
+++ b/app/components/action-feed/component.js
@@ -22,8 +22,8 @@ export default Component.extend({
 
     errorMessage: t('components.action-feed.error_loading'),
 
-    moreActions: computed('totalPages', 'page', function() {
-        return this.get('page') < this.get('totalPages');
+    moreActions: computed('totalPages', 'page', 'loadingMore', function() {
+        return this.get('loadingMore') ?  false : this.get('page') < this.get('totalPages');
     }),
 
     init() {

--- a/app/components/action-feed/component.js
+++ b/app/components/action-feed/component.js
@@ -22,8 +22,8 @@ export default Component.extend({
 
     errorMessage: t('components.action-feed.error_loading'),
 
-    moreActions: computed('totalPages', 'page', 'loadingMore', function() {
-        return this.get('loadingMore') ? false : this.get('page') < this.get('totalPages');
+    moreActions: computed('totalPages', 'page', function() {
+        return this.get('page') < this.get('totalPages');
     }),
 
     init() {

--- a/app/components/action-feed/template.hbs
+++ b/app/components/action-feed/template.hbs
@@ -10,7 +10,8 @@
         <div class='see-more'>
             <a role='button' {{action nextPage}}>{{t 'components.action-feed.see_more'}}</a>
         </div>
-    {{else if loadingMore}}
+    {{/if}}
+    {{#if loadingMore}}
         {{loading-indicator classes='ball-dark text-center loading'}}
     {{/if}}
 {{/if}}

--- a/app/components/action-feed/template.hbs
+++ b/app/components/action-feed/template.hbs
@@ -6,7 +6,7 @@
     {{else}}
         <div class="text-center">{{t 'components.action-feed.no_actions'}}</div>
     {{/each}}
-    {{#if moreActions}}
+    {{#if (and moreActions (not loadingMore))}}
         <div class='see-more'>
             <a role='button' {{action nextPage}}>{{t 'components.action-feed.see_more'}}</a>
         </div>


### PR DESCRIPTION
Clicking on "see more" link button on the dashboard is not showing the loading-indicator

![](http://g.recordit.co/x6KBmOjPir.gif)