### PR TITLE
[MOD-174][Hotfix] Fix moderator seeing old comment bug

### DIFF
--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -147,14 +147,7 @@ export default Component.extend({
     }),
 
     latestAction: computed('submission.actions.[]', function() {
-        if (!this.get('submission.actions.length')) {
-            return null;
-        }
-        // on create, Ember puts the new object at the end of the array
-        // https://stackoverflow.com/questions/15210249/ember-data-insert-new-item-at-beginning-of-array-instead-of-at-the-end
-        const first = this.get('submission.actions.firstObject');
-        const last = this.get('submission.actions.lastObject');
-        return moment(first.get('dateModified')) > moment(last.get('dateModified')) ? first : last;
+        return this._getRecentAction.bind(this.get('submission.actions'));
     }),
 
     noComment: computed('reviewerComment', function() {
@@ -229,7 +222,9 @@ export default Component.extend({
     }),
 
     init() {
-        this.get('submission.actions').then(this._handleActions.bind(this));
+        this.get('submission.actions')
+            .then(this._getRecentAction.bind(this))
+            .then(this._handleActions.bind(this));
         return this._super(...arguments);
     },
 
@@ -251,10 +246,23 @@ export default Component.extend({
         },
     },
 
-    _handleActions(actions) {
-        if (actions.length) {
+    _getRecentAction(actions) {
+        if (!actions.length) {
+            return null;
+        }
+
+        // on create, Ember puts the new object at the end of the array
+        // https://stackoverflow.com/questions/15210249/ember-data-insert-new-item-at-beginning-of-array-instead-of-at-the-end
+        const first = actions.get('firstObject');
+        const last = actions.get('lastObject');
+        return moment(first.get('dateModified')) > moment(last.get('dateModified')) ? first : last;
+    },
+
+    _handleActions(action) {
+        if (action) {
             if (this.get('submission.reviewsState') !== PENDING) {
-                const comment = actions.get('firstObject.comment');
+                const comment = action.get('comment');
+
                 this.set('initialReviewerComment', comment);
                 this.set('reviewerComment', comment);
                 this.set('decision', this.get('submission.reviewsState'));

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -223,7 +223,7 @@ export default Component.extend({
 
     init() {
         this.get('submission.actions')
-            .then(this._getRecentAction.bind(this))
+            .then(latestAction)
             .then(this._handleActions.bind(this));
         return this._super(...arguments);
     },
@@ -244,10 +244,6 @@ export default Component.extend({
             this.set('decision', this.get('submission.reviewsState'));
             this.set('reviewerComment', this.get('initialReviewerComment'));
         },
-    },
-
-    _getRecentAction(actions) {
-        return latestAction(actions);
     },
 
     _handleActions(action) {

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import moment from 'moment';
+import latestAction from 'reviews/utils/latest-action';
 
 const PENDING = 'pending';
 const ACCEPTED = 'accepted';
@@ -147,7 +147,7 @@ export default Component.extend({
     }),
 
     latestAction: computed('submission.actions.[]', function() {
-        return this._getRecentAction.bind(this.get('submission.actions'));
+        return latestAction(this.get('submission.actions'));
     }),
 
     noComment: computed('reviewerComment', function() {
@@ -247,15 +247,7 @@ export default Component.extend({
     },
 
     _getRecentAction(actions) {
-        if (!actions.length) {
-            return null;
-        }
-
-        // on create, Ember puts the new object at the end of the array
-        // https://stackoverflow.com/questions/15210249/ember-data-insert-new-item-at-beginning-of-array-instead-of-at-the-end
-        const first = actions.get('firstObject');
-        const last = actions.get('lastObject');
-        return moment(first.get('dateModified')) > moment(last.get('dateModified')) ? first : last;
+        return latestAction(actions);
     },
 
     _handleActions(action) {

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -12,7 +12,7 @@ export default Route.extend({
         return this.store.findRecord(
             'preprint',
             params.preprint_id,
-            { include: ['node', 'license', 'actions'], reload: true },
+            { include: ['node', 'license', 'actions'] },
         );
     },
 

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -9,7 +9,11 @@ export default Route.extend({
     currentUser: service(),
 
     model(params) {
-        return this.store.findRecord('preprint', params.preprint_id, { include: ['node', 'license', 'actions'] });
+        return this.store.findRecord(
+            'preprint',
+            params.preprint_id,
+            { include: ['node', 'license', 'actions'], reload: true },
+        );
     },
 
     afterModel(model) {

--- a/app/utils/latest-action.js
+++ b/app/utils/latest-action.js
@@ -1,0 +1,13 @@
+import moment from 'moment';
+
+
+export default function latestAction(actions) {
+    if (!actions.length) {
+        return null;
+    }
+    // on create, Ember puts the new object at the end of the array
+    // https://stackoverflow.com/questions/15210249/ember-data-insert-new-item-at-beginning-of-array-instead-of-at-the-end
+    const first = actions.get('firstObject');
+    const last = actions.get('lastObject');
+    return moment(first.get('dateModified')) > moment(last.get('dateModified')) ? first : last;
+}

--- a/tests/unit/utils/latest-action-test.js
+++ b/tests/unit/utils/latest-action-test.js
@@ -1,0 +1,36 @@
+import Object from '@ember/object';
+import latestAction from 'reviews/utils/latest-action';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | latest action');
+
+test('get first action - 2 actions', function(assert) {
+    const firstAction = Object.create({ dateModified: '2017-11-01T22:19:40.556278Z' });
+    const lastAction = Object.create({ dateModified: '2017-11-01T22:17:40.556278Z' });
+    const actions = [firstAction, lastAction];
+
+    const result = latestAction(actions);
+    assert.equal(result, firstAction);
+});
+
+test('get last action - 2 actions', function(assert) {
+    const firstAction = Object.create({ dateModified: '2017-11-01T22:17:40.556278Z' });
+    const lastAction = Object.create({ dateModified: '2017-11-01T22:19:40.556278Z' });
+    const actions = [firstAction, lastAction];
+
+    const result = latestAction(actions);
+    assert.equal(result, lastAction);
+});
+
+test('get first action - 1 actions', function(assert) {
+    const firstAction = Object.create({ dateModified: '2017-11-01T22:19:40.556278Z' });
+    const actions = [firstAction];
+
+    const result = latestAction(actions);
+    assert.equal(result, firstAction);
+});
+
+test('handle no actions - 0 actions', function(assert) {
+    const result = latestAction([]);
+    assert.equal(result, null);
+});


### PR DESCRIPTION
## Purpose
Fix the bug where moderators wouldn't see the most recent comment until they refreshed the page.

## Changes
Update `init` on preprint detail page to get the most recent action.

## Side Effects
None expected