### PR TITLE
[MOD-175][Hotfix] Include api version in queryHasMany request

### DIFF
--- a/app/routes/preprints/provider/moderation.js
+++ b/app/routes/preprints/provider/moderation.js
@@ -50,7 +50,7 @@ export default Route.extend({
     _resolveModel(response) {
         return {
             submissions: response.toArray(),
-            totalPages: Math.ceil(response.links.meta.total / response.links.meta.per_page),
+            totalPages: Math.ceil(response.meta.total / response.meta.per_page),
             statusCounts: response.meta.reviews_state_counts,
         };
     },

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -27,6 +27,9 @@ export default Store.extend({
             if (url) {
                 $.ajax(url, {
                     data: queryParams,
+                    headers: {
+                        ACCEPT: 'application/vnd.api+json; version=2.5',
+                    },
                     xhrFields: {
                         withCredentials: true,
                     },

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -19,6 +19,7 @@ export default Store.extend({
      * @returns {ArrayPromiseProxy} Promise-like array proxy, resolves to the records fetched
      */
     queryHasMany(model, propertyName, queryParams) {
+        // TODO: move queryHasMany to ember-osf (MOD-176)
         const reference = model.hasMany(propertyName);
         const promise = new EmberPromise((resolve, reject) => {
             // HACK: ember-data discards/ignores the link if an object on the belongsTo side


### PR DESCRIPTION
## Purpose
Prevent timezone issues.

## Changes
* Included header with api version in queryHasMany request.
    * Used version 2.5 because I get errors with 2.6
* Updated accessing the metadata since it changed between API version.

## Side effects
None expected.
