### PR TITLE
[Improvement][MOD-179] Remove name link from reviews dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Headless Firefox for tests
+- Integration tests for
+  - action-feed component
+  - action-feed-entry component
+  
 ### Changed
 - Remove global eslint rule and inline in router
 - Update travis to use Firefox
@@ -16,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use COS ember-base image and multi-stage build
   - Notify DevOps prior to merging into master to update Jenkins
 ### Removed
+- Remove name link from action logs in the dashboard view
+
 ### Fixed
 - Fix Loading indicator on Reviews dashboard which was not displaying when user clicks on see more link button. 
 - Add loading indicator for preprints titles on the Reviews dashboard.

--- a/app/components/action-feed-entry/template.hbs
+++ b/app/components/action-feed-entry/template.hbs
@@ -7,7 +7,7 @@
             {{moment-format action.dateCreated 'MMMM D, Y'}}
         </div>
         <div class="action-heading">
-            <a href={{action.creator.links.html}}>{{action.creator.fullName}}</a>
+            {{action.creator.fullName}}
             {{#if action.provider.isPending}}
                 {{loading-indicator classes='ball-dark'}}
             {{else}}

--- a/tests/integration/components/action-feed-entry/component-test.js
+++ b/tests/integration/components/action-feed-entry/component-test.js
@@ -1,0 +1,22 @@
+import EmberObject from '@ember/object';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('action-feed-entry', 'Integration | Component | action-feed-entry', {
+    integration: true,
+});
+
+
+test('it renders action-feed-entry', function(assert) {
+    this.set('action', EmberObject.create({
+        dateCreated: '2017-10-28T14:57:35.949534Z',
+        creator: { fullName: 'Po' },
+        provider: { name: 'viperXiv', preprintWord: 'preprint' },
+        actionTrigger: 'submit',
+        target: { title: 'the archive of all vipers' },
+    }));
+    this.set('toDetail', () => {});
+    this.render(hbs`{{action-feed-entry action=action toDetail=toDetail}}`);
+    assert.ok(this.$('.entry-body').length);
+    assert.equal(this.$('.entry-body').text().replace(/\s+/g, ' ').trim(), 'October 28, 2017 Po submitted a preprint to viperXiv the archive of all vipers');
+});

--- a/tests/integration/components/action-feed-entry/component-test.js
+++ b/tests/integration/components/action-feed-entry/component-test.js
@@ -13,10 +13,13 @@ test('it renders action-feed-entry', function(assert) {
         creator: { fullName: 'Po' },
         provider: { name: 'viperXiv', preprintWord: 'preprint' },
         actionTrigger: 'submit',
-        target: { title: 'the archive of all vipers' },
+        target: { title: 'Using machine learning for better bambo taste' },
     }));
     this.set('toDetail', () => {});
     this.render(hbs`{{action-feed-entry action=action toDetail=toDetail}}`);
     assert.ok(this.$('.entry-body').length);
-    assert.equal(this.$('.entry-body').text().replace(/\s+/g, ' ').trim(), 'October 28, 2017 Po submitted a preprint to viperXiv the archive of all vipers');
+    assert.equal(
+        this.$('.entry-body').text().replace(/\s+/g, ' ').trim(),
+        'October 28, 2017 Po submitted a preprint to viperXiv Using machine learning for better bambo taste',
+    );
 });

--- a/tests/integration/components/action-feed/component-test.js
+++ b/tests/integration/components/action-feed/component-test.js
@@ -1,0 +1,57 @@
+import EmberObject from '@ember/object';
+import EmberService from '@ember/service';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+
+// Stub store service
+const storeStub = EmberService.extend({
+    init() {
+        this._super(...arguments);
+        this.actionList = [EmberObject.create({ // Records to be returned by queryHasMany
+            dateCreated: '2017-10-28T14:57:35.949534Z',
+            creator: { fullName: 'Po' },
+            provider: { name: 'viperXiv', preprintWord: 'preprint' },
+            actionTrigger: 'submit',
+            target: { title: 'the archive of all vipers' },
+        }), EmberObject.create({
+            dateCreated: '2017-10-27T14:57:35.949534Z',
+            creator: { fullName: 'Tigerss' },
+            provider: { name: 'viperXiv', preprintWord: 'preprint' },
+            actionTrigger: 'submit',
+            target: { title: 'the archive of all vipers' },
+        })];
+    },
+    queryHasMany () {
+        return this.get('noActions') ? [] : this.get('actionList');
+    },
+});
+
+moduleForComponent('action-feed', 'Integration | Component | action-feed', {
+    integration: true,
+    beforeEach() {
+        this.register('service:store', storeStub);
+        this.inject.service('store', { as: 'store' });
+    },
+});
+
+
+test('it renders action-feed non-empty list', function(assert) {
+    this.set('store.noActions', false); // Store queryHasMany return records
+    this.set('toDetail', () => {});
+    this.render(hbs`{{action-feed toDetail=toDetail}}`);
+    assert.ok(this.$('.action-feed').length);
+    assert.equal(
+        this.$('.action-feed').text().replace(/\s+/g, ' ').trim(),
+        'October 28, 2017 Po submitted a preprint to viperXiv the archive of all vipers October 27, 2017 ' +
+        'Tigerss submitted a preprint to viperXiv the archive of all vipers',
+    );
+});
+
+test('it renders action-feed empty list', function(assert) {
+    this.set('store.noActions', true); // Store queryHasMany return no records
+    this.set('toDetail', () => {});
+    this.render(hbs`{{action-feed toDetail=toDetail}}`);
+    assert.ok(this.$('.action-feed').length);
+    assert.equal(this.$('.action-feed').text().replace(/\s+/g, ' ').trim(), 'No recent activity.');
+});


### PR DESCRIPTION
## Problem
Name link is the first link, so people click on it instead of the preprint link.

## Changes

- Remove name link
- Add test to action-feed-entry
![image](https://user-images.githubusercontent.com/11130339/32349181-93ad0b32-bfec-11e7-9cdc-b54f218c1476.png)

## Ticket
https://openscience.atlassian.net/browse/MOD-179