### PR TITLE
[Improvement][MOD-178] Disable the modify decision button until submission related actions are loaded

### DIFF
--- a/app/components/preprint-status-banner/style.scss
+++ b/app/components/preprint-status-banner/style.scss
@@ -65,7 +65,7 @@
       padding-right: 15px;
 
       .button-loading-indicator {
-        padding: 5px;
+        margin-right: 8px;
       }
       .dropdown-menu {
         font-size:62.5%;

--- a/app/components/preprint-status-banner/style.scss
+++ b/app/components/preprint-status-banner/style.scss
@@ -64,7 +64,7 @@
     .reviewer-feedback {
       padding-right: 15px;
 
-      i {
+      .button-loading-indicator {
         padding: 5px;
       }
       .dropdown-menu {

--- a/app/components/preprint-status-banner/style.scss
+++ b/app/components/preprint-status-banner/style.scss
@@ -64,6 +64,9 @@
     .reviewer-feedback {
       padding-right: 15px;
 
+      i {
+        padding: 5px;
+      }
       .dropdown-menu {
         font-size:62.5%;
         background-color: $color-bg-gray-lighter;

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -25,7 +25,7 @@
                 {{#dd.button type="success" disabled=submission.actions.isPending}}
                     {{#if submission.actions.isPending}}
                         <i class='button-loading-indicator fa fa-circle-o-notch fa-spin'></i>
-                        {{t 'components.preprint-status-banner.loading'}}...
+                        {{t 'components.preprint-status-banner.loading'}}
                     {{else}}
                         {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
                     {{/if}}

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -22,8 +22,12 @@
         </div>
         <div class="dropdown reviewer-feedback">
             {{#bs-dropdown closeOnMenuClick=false as |dd|}}
-                {{#dd.button type="success"}}
-                    {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
+                {{#dd.button type="success" disabled=submission.actions.isPending}}
+                    {{#if submission.actions.isPending}}
+                        <i class='fa fa-circle-o-notch fa-spin'></i> {{t 'components.preprint-status-banner.loading'}}
+                    {{else}}
+                        {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
+                    {{/if}}
                 {{/dd.button}}
                 {{#dd.menu}}
                     <div class="feedback-header">

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -24,7 +24,8 @@
             {{#bs-dropdown closeOnMenuClick=false as |dd|}}
                 {{#dd.button type="success" disabled=submission.actions.isPending}}
                     {{#if submission.actions.isPending}}
-                        <i class='fa fa-circle-o-notch fa-spin'></i> {{t 'components.preprint-status-banner.loading'}}
+                        <i class='fa fa-circle-o-notch fa-spin'></i>
+                        {{t 'components.preprint-status-banner.loading'}}...
                     {{else}}
                         {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
                     {{/if}}

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -24,7 +24,7 @@
             {{#bs-dropdown closeOnMenuClick=false as |dd|}}
                 {{#dd.button type="success" disabled=submission.actions.isPending}}
                     {{#if submission.actions.isPending}}
-                        <i class='fa fa-circle-o-notch fa-spin'></i>
+                        <i class='button-loading-indicator fa fa-circle-o-notch fa-spin'></i>
                         {{t 'components.preprint-status-banner.loading'}}...
                     {{else}}
                         {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -246,6 +246,7 @@ export default {
             pending: 'pending',
             accepted: 'accepted',
             rejected: 'rejected',
+            loading: 'Loading',
             decision: {
                 make_decision: 'Make decision',
                 modify_decision: 'Modify decision',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -246,7 +246,7 @@ export default {
             pending: 'pending',
             accepted: 'accepted',
             rejected: 'rejected',
-            loading: 'Loading',
+            loading: 'Loading...',
             decision: {
                 make_decision: 'Make decision',
                 modify_decision: 'Modify decision',


### PR DESCRIPTION
## Problem
If the user opens the moderator decision form right away they can't tell that the previous decision is still loading. This leads to confusion and possible error.

## Changes
Disable the **modify decision** button until submission related actions are loaded.

![](http://g.recordit.co/aPB4lRSRoQ.gif)

## Ticket
https://openscience.atlassian.net/browse/MOD-178