### PR TITLE
[Feature][MOD-181] Give warning on moderation detail page if reviewer input not submitted

### DIFF
--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -262,11 +262,7 @@ export default Component.extend({
             this.set('reviewerComment', this.get('initialReviewerComment'));
         },
         closeReviewerFeedback() {
-            if (this.get('decisionChanged') || this.get('commentEdited')){
-                this.set('userHasEnteredReview', true);
-            } else {
-                this.set('userHasEnteredReview', false);
-            }
+            this.set('userHasEnteredReview', this.get('userActivity'));
         },
     },
 

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -231,10 +231,7 @@ export default Component.extend({
     }),
 
     btnDisabled: computed('decisionChanged', 'commentEdited', 'saving', 'commentExceedsLimit', function() {
-        if (this.get('saving') || (!this.get('decisionChanged') && !this.get('commentEdited')) || this.get('commentExceedsLimit')) {
-            return true;
-        }
-        return false;
+        return this.get('saving') || (!this.get('decisionChanged') && !this.get('commentEdited')) || this.get('commentExceedsLimit');
     }),
 
     didInsertElement() {

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -121,6 +121,8 @@ export default Component.extend({
 
     commentExceedsLimit: computed.gt('reviewerComment.length', COMMENT_LIMIT),
 
+    userActivity: computed.or('commentEdited', 'decisionChanged'),
+
     commentLengthErrorMessage: computed('reviewerComment', function () {
         const i18n = this.get('i18n');
         return i18n.t('components.preprintStatusBanner.decision.commentLengthError', {
@@ -224,11 +226,8 @@ export default Component.extend({
     }),
 
     decisionChanged: computed('submission.reviewsState', 'decision', function() {
-        return this.get('submission.reviewsState') !== this.get('decision');
-    }),
-
-    userActivity: computed('commentEdited', 'decisionChanged', function () {
-        return this.get('commentEdited') || this.get('decisionChanged');
+        return ((this.get('submission.reviewsState') !== this.get('decision') && this.get('submission.reviewsState') !== PENDING) ||
+        (this.get('submission.reviewsState') === PENDING && this.get('decision') !== ACCEPTED));
     }),
 
     btnDisabled: computed('decisionChanged', 'commentEdited', 'saving', 'commentExceedsLimit', function() {

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -227,6 +227,10 @@ export default Component.extend({
         return this.get('submission.reviewsState') !== this.get('decision');
     }),
 
+    userActivity: computed('commentEdited', 'decisionChanged', function () {
+        return this.get('commentEdited') || this.get('decisionChanged');
+    }),
+
     btnDisabled: computed('decisionChanged', 'commentEdited', 'saving', 'commentExceedsLimit', function() {
         if (this.get('saving') || (!this.get('decisionChanged') && !this.get('commentEdited')) || this.get('commentExceedsLimit')) {
             return true;
@@ -256,6 +260,13 @@ export default Component.extend({
         cancel() {
             this.set('decision', this.get('submission.reviewsState'));
             this.set('reviewerComment', this.get('initialReviewerComment'));
+        },
+        closeReviewerFeedback() {
+            if (this.get('decisionChanged') || this.get('commentEdited')){
+                this.set('userHasEnteredReview', true);
+            } else {
+                this.set('userHasEnteredReview', false);
+            }
         },
     },
 

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -226,8 +226,7 @@ export default Component.extend({
     }),
 
     decisionChanged: computed('submission.reviewsState', 'decision', function() {
-        return ((this.get('submission.reviewsState') !== this.get('decision') && this.get('submission.reviewsState') !== PENDING) ||
-        (this.get('submission.reviewsState') === PENDING && this.get('decision') !== ACCEPTED));
+        return this.get('submission.reviewsState') !== this.get('decision') && this.get('decision') !== ACCEPTED;
     }),
 
     btnDisabled: computed('decisionChanged', 'commentEdited', 'saving', 'commentExceedsLimit', function() {

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -21,7 +21,7 @@
             {{/if}}
         </div>
         <div class="dropdown reviewer-feedback">
-            {{#bs-dropdown closeOnMenuClick=false as |dd|}}
+            {{#bs-dropdown onHide=(action 'closeReviewerFeedback') closeOnMenuClick=false as |dd|}}
                 {{#dd.button type="success" disabled=submission.actions.isPending}}
                     {{#if submission.actions.isPending}}
                         <i class='button-loading-indicator fa fa-circle-o-notch fa-spin'></i>

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -34,6 +34,10 @@ export default Controller.extend({
     _activeFile: null,
     chosenFile: null,
 
+    userHasEnteredReview: false,
+    showWarning: false,
+    previousTransition: null,
+
     hasTags: bool('node.tags.length'),
     expandedAbstract: navigator.userAgent.includes('Prerender'),
 
@@ -102,6 +106,17 @@ export default Controller.extend({
                 chosenFile: fileItem.get('id'),
                 activeFile: fileItem,
             });
+        },
+        leavePage() {
+            let previousTransition = this.get('previousTransition');
+            if (previousTransition) {
+                this.set('userHasEnteredReview', false);
+                this.set('showWarning', false);
+                previousTransition.retry();
+            }
+        },
+        hideWarning() {
+            this.set('showWarning', false);
         },
         submitDecision(trigger, comment, filter) {
             this.toggleProperty('savingAction');

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -108,7 +108,7 @@ export default Controller.extend({
             });
         },
         leavePage() {
-            let previousTransition = this.get('previousTransition');
+            const previousTransition = this.get('previousTransition');
             if (previousTransition) {
                 this.set('userHasEnteredReview', false);
                 this.set('showWarning', false);

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -166,6 +166,14 @@ export default {
             paragraph: 'The project for this paper is available on the OSF.',
             button: 'Visit project',
         },
+        warning: {
+            header: 'Discard your feedback',
+            body: 'Are you sure you want to leave without submitting your feedback? Your feedback will be discarded.',
+            footer: {
+                leave: 'Leave this page',
+                stay: 'Stay on this page',
+            },
+        },
     },
     components: {
         actionFeed: {

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -3,8 +3,9 @@ import $ from 'jquery';
 import { scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import ConfirmationMixin from 'ember-onbeforeunload/mixins/confirmation';
 
-export default Route.extend({
+export default Route.extend(ConfirmationMixin, {
     theme: service(),
     currentUser: service(),
 
@@ -45,6 +46,19 @@ export default Route.extend({
                 return this.intermediateTransitionTo('page-not-found');
             }
         },
+        willTransition(transition) {
+            if (this.controller.get('userHasEnteredReview')) {
+                this.controller.set('showWarning', true);
+                this.controller.set('previousTransition', transition);
+                transition.abort();
+            }
+        },
+    },
+
+    isPageDirty() {
+        // If true, shows a confirmation message when leaving the page
+        // True if the reviewer has any unsaved changes including comment edit or state change.
+        return this.controller.get('userHasEnteredReview');
     },
 
     _checkNodePublic(node) {

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -47,7 +47,7 @@ export default Route.extend(ConfirmationMixin, {
             }
         },
         willTransition(transition) {
-            if (this.controller.get('userHasEnteredReview')) {
+            if (this.isPageDirty()) {
                 this.controller.set('showWarning', true);
                 this.controller.set('previousTransition', transition);
                 transition.abort();

--- a/app/styles/modules/provider/_preprint-detail.scss
+++ b/app/styles/modules/provider/_preprint-detail.scss
@@ -12,3 +12,16 @@ section.preprint-license {
     width: 100%;
   }
 }
+
+.warning-header {
+  font-size: 20px;
+  padding: 5px 15px 8px 15px;
+
+  a {
+    color: grey;
+    float: right;
+  }
+}
+.setting-reminder {
+  font-size: 14px;
+}

--- a/app/styles/modules/provider/_preprint-detail.scss
+++ b/app/styles/modules/provider/_preprint-detail.scss
@@ -18,8 +18,7 @@ section.preprint-license {
   padding: 5px 15px 8px 15px;
 
   a {
-    color: grey;
-    float: right;
+    color: $color-text-gray-dark;
   }
 }
 .setting-reminder {

--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -14,7 +14,7 @@
         </div>
     </div>
 
-    {{preprint-status-banner submission=model saving=savingAction submitDecision=(action 'submitDecision')}}
+    {{preprint-status-banner submission=model saving=savingAction userHasEnteredReview=userHasEnteredReview submitDecision=(action 'submitDecision')}}
 
     <div id="view-page" class="container">
         <div class="row p-md">
@@ -136,4 +136,17 @@
 
         </div>
     </div>
+
+    {{#if showWarning}}
+        {{#bs-modal onHide=(action 'hideWarning') as |modal|}}
+            {{#modal.header}}
+                <div class="warning-header"><i class="fa fa-exclamation-triangle"></i> {{t 'content.warning.header'}}</div>
+            {{/modal.header}}
+            {{#modal.body}}<div class="warning-body">{{t 'content.warning.body'}}</div>{{/modal.body}}
+            {{#modal.footer}}
+                {{#bs-button onClick=(action 'leavePage')}}{{t 'content.warning.footer.leave'}}{{/bs-button}}
+                {{#bs-button onClick=(action 'hideWarning') type="info"}}{{t 'content.warning.footer.stay'}}{{/bs-button}}
+            {{/modal.footer}}
+        {{/bs-modal}}
+    {{/if}}
 </div>

--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -137,16 +137,14 @@
         </div>
     </div>
 
-    {{#if showWarning}}
-        {{#bs-modal onHide=(action 'hideWarning') as |modal|}}
-            {{#modal.header}}
-                <div class="warning-header"><i class="fa fa-exclamation-triangle"></i> {{t 'content.warning.header'}}</div>
-            {{/modal.header}}
-            {{#modal.body}}<div class="warning-body">{{t 'content.warning.body'}}</div>{{/modal.body}}
-            {{#modal.footer}}
-                {{#bs-button onClick=(action 'leavePage')}}{{t 'content.warning.footer.leave'}}{{/bs-button}}
-                {{#bs-button onClick=(action 'hideWarning') type="info"}}{{t 'content.warning.footer.stay'}}{{/bs-button}}
-            {{/modal.footer}}
-        {{/bs-modal}}
-    {{/if}}
+    {{#bs-modal open=showWarning onHide=(action 'hideWarning') as |modal|}}
+        {{#modal.header}}
+            <div class="warning-header"><i class="fa fa-exclamation-triangle"></i> {{t 'content.warning.header'}}</div>
+        {{/modal.header}}
+        {{#modal.body}}<div class="warning-body">{{t 'content.warning.body'}}</div>{{/modal.body}}
+        {{#modal.footer}}
+            {{#bs-button onClick=(action 'hideWarning') type="info"}}{{t 'content.warning.footer.stay'}}{{/bs-button}}
+            {{#bs-button onClick=(action 'leavePage')}}{{t 'content.warning.footer.leave'}}{{/bs-button}}
+        {{/modal.footer}}
+    {{/bs-modal}}
 </div>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-i18n": "5.0.2",
     "ember-load-initializers": "^1.0.0",
     "ember-moment": "^7.4.1",
+    "ember-onbeforeunload": "^1.1.2",
     "ember-parachute": "^0.3.5",
     "ember-radio-button": "^1.1.1",
     "ember-resolver": "^4.0.0",

--- a/tests/unit/components/preprint-file-browser-test.js
+++ b/tests/unit/components/preprint-file-browser-test.js
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { moduleForComponent } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
 
@@ -56,7 +55,7 @@ test('page computed property', function(assert) {
     component.set('pageNumber', 1);
 
     component.set('files', ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7']);
-    assert.deepEqual(component.get('page'), [ "f7"]);
+    assert.deepEqual(component.get('page'), ['f7']);
 
     component.set('pageNumber', 2);
     assert.deepEqual(component.get('page'), []);

--- a/tests/unit/components/preprint-file-browser-test.js
+++ b/tests/unit/components/preprint-file-browser-test.js
@@ -1,0 +1,96 @@
+import { run } from '@ember/runloop';
+import { moduleForComponent } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+
+
+moduleForComponent('preprint-file-browser', 'Unit | Component | preprint file browser', {
+    unit: true,
+    needs: [
+        'model:action',
+        'model:node',
+        'model:user',
+        'model:preprint',
+        'model:preprint-provider',
+        'model:file-provider',
+        'model:file',
+        'service:i18n',
+        'service:theme',
+    ],
+});
+
+test('hasPrev computed property', function(assert) {
+    const component = this.subject();
+    assert.ok(component);
+
+    component.set('pageNumber', 0);
+    assert.ok(!component.get('hasPrev'));
+
+    component.set('pageNumber', 4);
+    assert.ok(component.get('hasPrev'));
+});
+
+test('hasNext computed property', function(assert) {
+    const component = this.subject();
+    assert.ok(component);
+    component.set('pageNumber', 1);
+
+    component.set('files', ['f1', 'f2', 'f3']);
+    assert.ok(!component.get('hasNext'));
+
+    component.set('files', ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7']);
+    assert.ok(!component.get('hasNext'));
+});
+
+test('fileIsPrimary computed property', function(assert) {
+    const component = this.subject();
+    assert.ok(component);
+    component.set('selectedFile', 'f1');
+
+    component.set('primaryFile', 'f1');
+    assert.ok(component.get('fileIsPrimary'));
+});
+
+test('page computed property', function(assert) {
+    const component = this.subject();
+    assert.ok(component);
+    component.set('pageNumber', 1);
+
+    component.set('files', ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7']);
+    assert.deepEqual(component.get('page'), [ "f7"]);
+
+    component.set('pageNumber', 2);
+    assert.deepEqual(component.get('page'), []);
+});
+
+test('didReceiveAttrs function', function(assert) {
+    const component = this.subject();
+    assert.ok(component);
+    component.set('pageNumber', 1);
+
+    component.set('selectedFile', 'f1');
+
+    component.set('primaryFile', 'f2');
+    assert.ok(component.get('selectedFile') !== component.get('primaryFile'));
+
+    component.didReceiveAttrs();
+    assert.strictEqual(component.get('selectedFile'), component.get('primaryFile'));
+});
+
+test('page action', function(assert) {
+    const component = this.subject();
+    assert.ok(component);
+    component.set('pageNumber', 1);
+
+    component.send('page', 5);
+    assert.strictEqual(component.get('pageNumber'), 6);
+});
+
+test('selectFile action', function(assert) {
+    const component = this.subject();
+    assert.ok(component);
+
+    component.set('selectedFile', 'f1');
+    component.send('selectFile', 'f2');
+
+    assert.strictEqual(component.get('selectedFile'), 'f2');
+});

--- a/tests/unit/components/preprint-file-browser-test.js
+++ b/tests/unit/components/preprint-file-browser-test.js
@@ -5,15 +5,11 @@ import test from 'ember-sinon-qunit/test-support/test';
 moduleForComponent('preprint-file-browser', 'Unit | Component | preprint file browser', {
     unit: true,
     needs: [
-        'model:action',
         'model:node',
-        'model:user',
         'model:preprint',
         'model:preprint-provider',
         'model:file-provider',
         'model:file',
-        'service:i18n',
-        'service:theme',
     ],
 });
 

--- a/tests/unit/components/preprint-status-banner-test.js
+++ b/tests/unit/components/preprint-status-banner-test.js
@@ -298,3 +298,29 @@ test('commentLengthErrorMessage computed property', function(assert) {
     component.set('reviewerComment', 'test comment for error message'.repeat(2000));
     assert.strictEqual(component.get('commentLengthErrorMessage'), 'Comment is 5535 character(s) too long (maximum is 65535).');
 });
+
+test('userActivity computed property', function(assert) {
+    const component = this.subject();
+
+    component.set('commentEdited', true);
+    component.set('decisionChanged', true);
+    assert.ok(component.get('userActivity'));
+    component.set('decisionChanged', false);
+    assert.ok(component.get('userActivity'));
+    component.set('commentEdited', false);
+    assert.ok(!component.get('userActivity'));
+});
+
+test('closeReviewerFeedback computed property', function(assert) {
+    const component = this.subject();
+
+    component.set('commentEdited', true);
+    component.set('decisionChanged', true);
+    component.send('closeReviewerFeedback');
+    assert.ok(component.get('userHasEnteredReview'));
+
+    component.set('commentEdited', false);
+    component.set('decisionChanged', false);
+    component.send('closeReviewerFeedback');
+    assert.ok(!component.get('userHasEnteredReview'));
+});

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -287,12 +287,6 @@ test('fileDownloadURL computed property', function (assert) {
     const ctrl = this.subject();
 
     run(() => {
-        const origin = 'http://localhost:4200';
-
-        const window = { location: { origin } };
-
-        ctrl.set('window', window);
-
         const node = this.store.createRecord('node', {
             description: 'test description',
         });
@@ -302,6 +296,32 @@ test('fileDownloadURL computed property', function (assert) {
         ctrl.setProperties({ model });
         ctrl.set('model.id', '6gtu');
 
-        assert.strictEqual(ctrl.get('fileDownloadURL'), 'http://localhost:4201/6gtu/download');
+        const url = ctrl.get('fileDownloadURL').split(ctrl.get('model.id'));
+        assert.strictEqual(url[1], '/download');
     });
+});
+
+test('hideWarning action', function (assert) {
+    const ctrl = this.subject();
+    ctrl.set('showWarning', true);
+    ctrl.send('hideWarning');
+    assert.ok(!ctrl.get('showWarning'));
+});
+
+test('leavePage action', function (assert) {
+    const ctrl = this.subject();
+
+    ctrl.send('leavePage');
+    assert.ok(!ctrl.get('showWarning'));
+    assert.ok(!ctrl.get('userHasEnteredReview'));
+
+    const stubTransition = { retry() {} };
+    const stub = this.stub(stubTransition, 'retry');
+    ctrl.set('previousTransition', stubTransition);
+    ctrl.set('userHasEnteredReview', true);
+    ctrl.set('showWarning', true);
+    ctrl.send('leavePage');
+    assert.ok(!ctrl.get('showWarning'));
+    assert.ok(!ctrl.get('userHasEnteredReview'));
+    assert.ok(stub.calledOnce);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,10 +478,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -3438,6 +3434,12 @@ ember-moment@^7.4.1:
     ember-getowner-polyfill "^2.0.1"
     ember-macro-helpers "^0.17.0"
 
+ember-onbeforeunload@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ember-onbeforeunload/-/ember-onbeforeunload-1.1.2.tgz#0874a75a4dfc77cb6c8dba7333e5cf4a87d91bae"
+  dependencies:
+    ember-cli-babel "^6.3.0"
+
 ember-parachute@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/ember-parachute/-/ember-parachute-0.3.5.tgz#207830d5d071ac70c824ef1d68a668f1f0022de2"
@@ -4572,7 +4574,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1, glob@^7.0.0:
+glob@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -4593,7 +4595,7 @@ glob@^5.0.10, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -5284,14 +5286,14 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.8.4:
+js-yaml@3.8.4, js-yaml@^3.6.1:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
-js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.6.1, js-yaml@^3.9.1:
+js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -7140,20 +7142,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
## Problem
If a reviewer accidentally exits the decision form we don't want them to navigate away from the page without making a decision.

## Goal
Give warning on moderation detail page if reviewer input (e.g. new/edit comment or change of decision) not submitted and reviewer tries to leave the page.

## Changes

- Update preprint-status-banner component
- Update preprint-detail page template, controller, and router
- Update translation file
- Add new addon ember-onbeforeunload for case 1 (see next)
- Add new unit tests

**Two cases**
- When user reloads or closes the page or navigate to OSF or another external app
![](http://recordit.co/F048haM1NA.gif)

- When user navigates to another route with-in the reviews app
![](http://recordit.co/SKizjgtzQh.gif)

## Ticket 
https://openscience.atlassian.net/browse/MOD-181

