### PR TITLE
[MOD-197][Improvement] actions --> reviewActions

### DIFF
--- a/app/components/action-feed/component.js
+++ b/app/components/action-feed/component.js
@@ -1,7 +1,6 @@
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { translationMacro as t } from 'ember-i18n';
 import { task } from 'ember-concurrency';
 
 /**
@@ -17,11 +16,11 @@ import { task } from 'ember-concurrency';
 export default Component.extend({
     store: service(),
     toast: service(),
+    i18n: service(),
+
     currentUser: service(),
     classNames: ['action-feed'],
     page: 0,
-
-    errorMessage: t('components.actionFeed.errorLoading'),
 
     dummyActionList: computed(function() {
         return new Array(10);
@@ -42,7 +41,7 @@ export default Component.extend({
         const page = this.get('page');
         try {
             const user = yield this.get('currentUser.user');
-            const actions = yield this.get('store').queryHasMany(user, 'actions', {
+            const actions = yield this.get('store').queryHasMany(user, 'reviewActions', {
                 page,
                 embed: 'target',
             });
@@ -52,7 +51,8 @@ export default Component.extend({
                 Math.ceil(actions.get('meta.total') / actions.get('meta.per_page')),
             );
         } catch (e) {
-            this.get('toast').error(this.get('errorMessage'));
+            this.get('toast')
+                .error(this.get('i18n').t('components.actionFeed.errorLoading'));
         }
     }).drop(),
 });

--- a/app/components/action-feed/component.js
+++ b/app/components/action-feed/component.js
@@ -40,15 +40,14 @@ export default Component.extend({
         this.incrementProperty('page');
         const page = this.get('page');
         try {
-            const user = yield this.get('currentUser.user');
-            const actions = yield this.get('store').queryHasMany(user, 'reviewActions', {
+            const actions = yield this.get('store').query('review-action', {
                 page,
-                embed: 'target',
+                embed: ['target'],
             });
             this.get('actionsList').pushObjects(actions.toArray());
             this.set(
                 'totalPages',
-                Math.ceil(actions.get('meta.total') / actions.get('meta.per_page')),
+                Math.ceil(actions.get('meta.pagination.total') / actions.get('meta.pagination.per_page')),
             );
         } catch (e) {
             this.get('toast')

--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -37,10 +37,10 @@ export default Component.extend({
 
     latestActionCreator: computed.alias('latestAction.creator.fullName'),
 
-    noActions: computed.not('submission.actions.length'),
+    noActions: computed.not('submission.reviewActions.length'),
 
-    latestAction: computed('submission.actions.[]', function() {
-        return latestAction(this.get('submission.actions'));
+    latestAction: computed('submission.reviewActions.[]', function() {
+        return latestAction(this.get('submission.reviewActions'));
     }),
 
     firstContributors: computed('submission.node.contributors', function() {
@@ -82,6 +82,6 @@ export default Component.extend({
     fetchData: task(function* () {
         const node = yield this.get('submission.node');
         yield node.get('contributors');
-        yield this.get('submission.actions');
+        yield this.get('submission.reviewActions');
     }),
 });

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -159,8 +159,8 @@ export default Component.extend({
             CLASS_NAMES[this.get('submission.reviewsState')];
     }),
 
-    latestAction: computed('submission.actions.[]', function() {
-        return latestAction(this.get('submission.actions'));
+    latestAction: computed('submission.reviewActions.[]', function() {
+        return latestAction(this.get('submission.reviewActions'));
     }),
 
     noComment: computed('reviewerComment', function() {
@@ -235,7 +235,7 @@ export default Component.extend({
     }),
 
     didInsertElement() {
-        this.get('submission.actions')
+        this.get('submission.reviewActions')
             .then(latestAction)
             .then(this._handleActions.bind(this));
         return this._super(...arguments);

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -22,8 +22,8 @@
         </div>
         <div class="dropdown reviewer-feedback">
             {{#bs-dropdown closeOnMenuClick=false as |dd|}}
-                {{#dd.button type="success" disabled=submission.actions.isPending}}
-                    {{#if submission.actions.isPending}}
+                {{#dd.button type="success" disabled=submission.reviewActions.isPending}}
+                    {{#if submission.reviewActions.isPending}}
                         <i class='button-loading-indicator fa fa-circle-o-notch fa-spin'></i>
                         {{t 'components.preprint-status-banner.loading'}}
                     {{else}}

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -106,7 +106,7 @@ export default Controller.extend({
         submitDecision(trigger, comment, filter) {
             this.toggleProperty('savingAction');
 
-            const action = this.store.createRecord('action', {
+            const action = this.store.createRecord('review-action', {
                 actionTrigger: trigger,
                 target: this.get('model'),
             });

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -12,7 +12,7 @@ export default Route.extend({
         return this.store.findRecord(
             'preprint',
             params.preprint_id,
-            { include: ['node', 'license', 'actions'] },
+            { include: ['node', 'license', 'review_actions'] },
         );
     },
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:cover": "COVERAGE=true yarn test"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf#feature/reviews#2017-10-26",
+    "@centerforopenscience/ember-osf": "https://github.com/laurenbarker/ember-osf#bddae519b7419189c83dc8886fd99c63ef4d82fa",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@cos-forks/ember-content-placeholders": "https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc",
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/integration/components/action-feed/component-test.js
+++ b/tests/integration/components/action-feed/component-test.js
@@ -8,7 +8,7 @@ import hbs from 'htmlbars-inline-precompile';
 const storeStub = EmberService.extend({
     init() {
         this._super(...arguments);
-        this.actionList = [EmberObject.create({ // Records to be returned by queryHasMany
+        this.actionList = [EmberObject.create({ // Records to be returned by query
             dateCreated: '2017-10-28T14:57:35.949534Z',
             creator: { fullName: 'Po' },
             provider: { name: 'viperXiv', preprintWord: 'preprint' },
@@ -22,7 +22,7 @@ const storeStub = EmberService.extend({
             target: { title: 'the archive of all vipers' },
         })];
     },
-    queryHasMany () {
+    query() {
         return this.get('noActions') ? [] : this.get('actionList');
     },
 });

--- a/tests/integration/components/moderation-list-row/component-test.js
+++ b/tests/integration/components/moderation-list-row/component-test.js
@@ -7,10 +7,10 @@ moduleForComponent('moderation-list-row', 'Integration | Component | moderation-
 });
 
 
-test('it renders moderation-list-row accepted with actions', function(assert) {
+test('it renders moderation-list-row accepted with reviewActions', function(assert) {
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
-        actions: [
+        reviewActions: [
             EmberObject.create({
                 fromState: 'pending',
                 toState: 'accepted',
@@ -35,10 +35,10 @@ test('it renders moderation-list-row accepted with actions', function(assert) {
     assert.equal(this.$('[data-status=accepted]').text().trim(), 'accepted on October 27, 2017 by Kung-fu Panda');
 });
 
-test('it renders moderation-list-row accepted without actions', function(assert) {
+test('it renders moderation-list-row accepted without reviewActions', function(assert) {
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
-        actions: [],
+        reviewActions: [],
         reviewsState: 'accepted',
         node: EmberObject.create({ contributors: ['Tigerss', 'Crane'] }),
     });
@@ -46,10 +46,10 @@ test('it renders moderation-list-row accepted without actions', function(assert)
     assert.equal(this.$('[data-status=accepted]').text().trim(), 'accepted automatically on October 27, 2017');
 });
 
-test('it renders moderation-list-row rejected with actions', function(assert) {
+test('it renders moderation-list-row rejected with reviewActions', function(assert) {
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
-        actions: [
+        reviewActions: [
             EmberObject.create({
                 fromState: 'pending',
                 toState: 'rejected',
@@ -70,10 +70,10 @@ test('it renders moderation-list-row rejected with actions', function(assert) {
     assert.equal(this.$('[data-status=rejected]').text().trim(), 'rejected on October 27, 2017 by Master Shifu');
 });
 
-test('it renders moderation-list-row pending with actions', function(assert) {
+test('it renders moderation-list-row pending with reviewActions', function(assert) {
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
-        actions: [
+        reviewActions: [
             EmberObject.create({
                 fromState: 'initial',
                 toState: 'pending',
@@ -90,10 +90,10 @@ test('it renders moderation-list-row pending with actions', function(assert) {
     assert.equal(this.$('[data-status=pending]').text().replace(/\n/g, ' ').trim(), 'submitted on October 27, 2017 by Mr. Ping Mantis');
 });
 
-test('it renders moderation-list-row pending with actions and more than three contributors', function(assert) {
+test('it renders moderation-list-row pending with reviewActions and more than three contributors', function(assert) {
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
-        actions: [
+        reviewActions: [
             EmberObject.create({
                 fromState: 'initial',
                 toState: 'pending',

--- a/tests/integration/components/moderation-list/component-test.js
+++ b/tests/integration/components/moderation-list/component-test.js
@@ -54,7 +54,7 @@ test('moderation-list full page submissions', function(assert) {
 
     const submission = {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
-        actions: [
+        reviewActions: [
             EmberObject.create({
                 fromState: 'initial',
                 toState: 'pending',

--- a/tests/integration/components/preprint-status-banner/component-test.js
+++ b/tests/integration/components/preprint-status-banner/component-test.js
@@ -12,7 +12,7 @@ test('it renders preprint-status-banner', function(assert) {
     this.set('savingAction', false);
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
-        actions: new Promise(function(resolve) { resolve([]); }),
+        reviewActions: new Promise(function(resolve) { resolve([]); }),
         reviewsState: 'accepted',
         provider: { reviewsWorkflow: 'pre-moderation' },
         node: { contributors: [{ users: { fullName: 'Mr. Ping' } }, { users: { fullName: 'Mantis' } }] },

--- a/tests/unit/components/preprint-status-banner-test.js
+++ b/tests/unit/components/preprint-status-banner-test.js
@@ -10,7 +10,7 @@ moduleForComponent('preprint-status-banner', 'Unit | Component | preprint status
     // needs: ['component:foo', 'helper:bar'],
     unit: true,
     needs: [
-        'model:action',
+        'model:review-action',
         'model:node',
         'model:user',
         'model:preprint',
@@ -128,19 +128,19 @@ test('latestAction computed property', function(assert) {
             reviewsWorkflow: 'pre-moderation',
         });
 
-        const actions = [
-            this.store.createRecord('action', {
+        const reviewActions = [
+            this.store.createRecord('review-action', {
                 fromState: 'rejected', toState: 'accepted', dateModified: '2017-10-29T14:57:35.949534Z', creator: { fullName: 'Kung-fu Panda' },
             }),
-            this.store.createRecord('action', {
+            this.store.createRecord('review-action', {
                 fromState: 'pending', toState: 'rejected', dateModified: '2017-10-27T14:57:35.949534Z', creator: { fullName: 'Po' },
             }),
-            this.store.createRecord('action', {
+            this.store.createRecord('review-action', {
                 fromState: 'initial', toState: 'pending', dateModified: '2017-10-25T14:57:35.949534Z', creator: { fullName: 'Viper' },
             }),
         ];
 
-        const submission = this.store.createRecord('preprint', { node, provider, actions });
+        const submission = this.store.createRecord('preprint', { node, provider, reviewActions });
         component.setProperties({ submission });
 
         assert.strictEqual(component.get('latestAction.dateModified'), '2017-10-29T14:57:35.949534Z');
@@ -241,7 +241,7 @@ test('_handleActions  action', function(assert) {
             description: 'test description',
         });
 
-        const action = this.store.createRecord('action', {
+        const action = this.store.createRecord('review-action', {
             fromState: 'rejected',
             toState: 'accepted',
             dateModified: '2017-10-29T14:57:35.949534Z',

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -4,7 +4,7 @@ import test from 'ember-sinon-qunit/test-support/test';
 
 moduleFor('controller:preprints/provider/preprint-detail', 'Unit | Controller | preprints/provider/preprint-detail', {
     needs: [
-        'model:action',
+        'model:review-action',
         'model:file',
         'model:file-version',
         'model:comment',

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf#feature/reviews#2017-10-26":
+"@centerforopenscience/ember-osf@https://github.com/laurenbarker/ember-osf#bddae519b7419189c83dc8886fd99c63ef4d82fa":
   version "0.11.1"
-  resolved "https://github.com/CenterForOpenScience/ember-osf#21d464a0f92b1fd08a18f838ef961e5760f30a8f"
+  resolved "https://github.com/laurenbarker/ember-osf#bddae519b7419189c83dc8886fd99c63ef4d82fa"
   dependencies:
     bootstrap-sass "^3.3.7"
     broccoli-funnel "1.2.0"
@@ -2757,7 +2757,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cl
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.9.0.tgz#5147391389bdbb7091d15f81ae1dff1eb49d71aa"
   dependencies:
@@ -2773,6 +2773,24 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     broccoli-source "^1.1.0"
     clone "^2.0.0"
     ember-cli-version-checker "^2.1.0"
+
+ember-cli-babel@^6.1.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz#81424acd1d97fb13658168121eeb2007d6edee84"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+    semver "^5.4.1"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
*The ember-osf-reviews changes rely on the API changes and ember-osf changes in the related tickets below.*

## Purpose
Change `actions` --> `reviewActions` to support generalizing the actions API.

Related tickets: 
* https://github.com/CenterForOpenScience/osf.io/pull/7924 but with updated changes https://github.com/mfraezz/osf.io/tree/feature/request-actions
* https://github.com/CenterForOpenScience/ember-osf/pull/329
    * will need to be merged into our version of ember-osf (they aren't merged quite yet)

## Changes
* mainly just update the name
* actions for the actions-list are loaded from `reviews/actions` instead of the user relationship

## QA notes
* regression for moderation functionality; everything should work the same