### PR TITLE
[Feature][MOD-191] Add submitted by to the accepted/rejected records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show moderator name (instead of creator) in the accepted/rejected records in the moderation list
 - Update style/layout for Reviews to be more mobile friendly 
 - Update language 
-  - Add `Submitted by` along with the `accepted by/rejected by` for records under accepted/rejected tabs in moderation list
+  - Add `Submitted by` along with the `accepted by/rejected by` for the accepted/rejected records in the moderation list
   - Capitalize first letter (e.g `submitted by` to `Submitted by`) 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Notify DevOps prior to merging into master to update Jenkins
 - Show moderator name (instead of creator) in the accepted/rejected records in the moderation list
 - Update style/layout for Reviews to be more mobile friendly 
+- Update language 
+  - Add `Submitted by` along with the `accepted by/rejected by` for records under accepted/rejected tabs in moderation list
+  - Capitalize first letter (e.g `submitted by` to `Submitted by`) 
 
 
 ### Removed

--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -54,29 +54,22 @@ export default Component.extend({
         return this.get('submission.node.contributors.content.meta.pagination.total') - 3;
     }),
 
-    gtDay: computed('submission.dateLastTransitioned', function() {
-        return moment().diff(this.get('submission.dateLastTransitioned'), 'days') > 1;
-    }),
-
-    // date of preprint acceptance or rejection
-    acceptedRejectedDate: computed('submission.dateLastTransitioned', 'gtDay', function() {
-        return this.get('gtDay') ?
+    // translations for moderator action label
+    reviewedOnLabel: computed('submission.{reviewsState,dateLastTransitioned}', 'noActions', 'latestActionCreator', function() {
+        const gtDay = moment().diff(this.get('submission.dateLastTransitioned'), 'days') > 1;
+        const acceptedRejectedDate = gtDay ?
             moment(this.get('submission.dateLastTransitioned')).format('MMMM DD, YYYY') :
             moment(Math.min(Date.parse(this.get('submission.dateLastTransitioned')), Date.now())).fromNow();
-    }),
-
-    // translations for moderator action label
-    reviewedOnLabel: computed('submission.reviewsState', 'gtDay', 'noActions', 'acceptedRejectedDate', 'latestActionCreator', function() {
         const i18n = this.get('i18n');
-        const dayValue = this.get('gtDay') ? 'gtDay' : 'ltDay';
+        const dayValue = gtDay ? 'gtDay' : 'ltDay';
         const timeWording = this.get('noActions') ? `${dayValue}_automatic` : dayValue;
         const status = this.get('submission.reviewsState');
         const labels = ACTION_LABELS[status][timeWording];
-        return i18n.t(labels, { timeDate: this.get('acceptedRejectedDate'), moderatorName: this.get('latestActionCreator') });
+        return i18n.t(labels, { timeDate: acceptedRejectedDate, moderatorName: this.get('latestActionCreator') });
     }),
 
     // translations for submitted on label
-    submittedOnLabel: computed('gtDay', 'submission.dateCreated', function() {
+    submittedOnLabel: computed('submission.dateCreated', function() {
         const i18n = this.get('i18n');
         const gtDaySubmit = moment().diff(this.get('submission.dateCreated'), 'days') > 1;
         const dayValue = gtDaySubmit ? 'gtDay' : 'ltDay';

--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -39,35 +39,56 @@ export default Component.extend({
 
     noActions: computed.not('submission.actions.length'),
 
+    // latest action attempted on the preprint
     latestAction: computed('submission.actions.[]', function() {
         return latestAction(this.get('submission.actions'));
     }),
 
+    // first three contributors to the preprint
     firstContributors: computed('submission.node.contributors', function() {
         return this.get('submission.node.contributors').slice(0, 3);
     }),
 
+    // count of contributors in-addition to the first three
     additionalContributors: computed('submission.node.contributors', function() {
         return this.get('submission.node.contributors.content.meta.pagination.total') - 3;
     }),
 
+    // check if it has been more than a day since preprint last transition
     gtDay: computed('submission.dateLastTransitioned', function() {
         return moment().diff(this.get('submission.dateLastTransitioned'), 'days') > 1;
     }),
 
-    relevantDate: computed('submission.dateLastTransitioned', 'gtDay', function() {
+    // date of preprint acceptance or rejection
+    acceptedRejectedtDate: computed('submission.dateLastTransitioned', 'gtDay', function() {
         return this.get('gtDay') ?
             moment(this.get('submission.dateLastTransitioned')).format('MMMM DD, YYYY') :
             moment(Math.min(Date.parse(this.get('submission.dateLastTransitioned')), Date.now())).fromNow();
     }),
 
-    // translations
-    statusTimeDate: computed('submission.reviewsState', 'gtDay', 'noActions', function() {
+    // date of preprint submission
+    submitDate: computed('submission.dateCreated', 'gtDay', function() {
+        return this.get('gtDay') ?
+            moment(this.get('submission.dateCreated')).format('MMMM DD, YYYY') :
+            moment(Math.min(Date.parse(this.get('submission.dateCreated')), Date.now())).fromNow();
+    }),
+
+    // translations for accepted and rejected records
+    acceptedRejectedStatusTimeDate: computed('submission.reviewsState', 'gtDay', 'noActions', function() {
         const i18n = this.get('i18n');
         const dayValue = this.get('gtDay') ? 'gtDay' : 'ltDay';
         const timeWording = this.get('noActions') ? `${dayValue}_automatic` : dayValue;
-        const labels = ACTION_LABELS[this.get('submission.reviewsState')][timeWording];
-        return i18n.t(labels, { timeDate: this.get('relevantDate'), moderatorName: this.get('latestActionCreator') });
+        const status = this.get('submission.reviewsState');
+        const labels = ACTION_LABELS[status][timeWording];
+        return i18n.t(labels, { timeDate: this.get('acceptedRejectedtDate'), moderatorName: this.get('latestActionCreator') });
+    }),
+
+    // translations for pending records
+    pendingStatusTimeDate: computed('submission.reviewsState', 'gtDay', 'noActions', function() {
+        const i18n = this.get('i18n');
+        const dayValue = this.get('gtDay') ? 'gtDay' : 'ltDay';
+        const labels = ACTION_LABELS.pending[dayValue];
+        return i18n.t(labels, { timeDate: this.get('submitDate') });
     }),
 
     didReceiveAttrs() {

--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -66,7 +66,7 @@ export default Component.extend({
     }),
 
     // translations for moderator action label
-    reviewedOnLabel: computed('submission.reviewsState', 'gtDay', 'noActions', function() {
+    reviewedOnLabel: computed('submission.reviewsState', 'gtDay', 'noActions', 'acceptedRejectedDate', 'latestActionCreator', function() {
         const i18n = this.get('i18n');
         const dayValue = this.get('gtDay') ? 'gtDay' : 'ltDay';
         const timeWording = this.get('noActions') ? `${dayValue}_automatic` : dayValue;
@@ -76,7 +76,7 @@ export default Component.extend({
     }),
 
     // translations for submitted on label
-    submittedOnLabel: computed('gtDaySubmit', 'submission.dateCreated', function() {
+    submittedOnLabel: computed('gtDay', 'submission.dateCreated', function() {
         const i18n = this.get('i18n');
         const gtDaySubmit = moment().diff(this.get('submission.dateCreated'), 'days') > 1;
         const dayValue = gtDaySubmit ? 'gtDay' : 'ltDay';

--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -70,7 +70,6 @@ export default Component.extend({
         const i18n = this.get('i18n');
         const dayValue = this.get('gtDay') ? 'gtDay' : 'ltDay';
         const timeWording = this.get('noActions') ? `${dayValue}_automatic` : dayValue;
-        console.log(dayValue);
         const status = this.get('submission.reviewsState');
         const labels = ACTION_LABELS[status][timeWording];
         return i18n.t(labels, { timeDate: this.get('acceptedRejectedDate'), moderatorName: this.get('latestActionCreator') });

--- a/app/components/moderation-list-row/style.scss
+++ b/app/components/moderation-list-row/style.scss
@@ -42,8 +42,7 @@
     content: ", "
   }
   li:last-child:after {
-    content: "\a";
-    white-space: pre;
+    content: "";
   }
 }
 

--- a/app/components/moderation-list-row/style.scss
+++ b/app/components/moderation-list-row/style.scss
@@ -42,7 +42,8 @@
     content: ", "
   }
   li:last-child:after {
-    content: "";
+    content: "\a";
+    white-space: pre;
   }
 }
 

--- a/app/components/moderation-list-row/template.hbs
+++ b/app/components/moderation-list-row/template.hbs
@@ -16,11 +16,9 @@
                             + {{additionalContributors}}
                         {{/if}}
                     </div>
-                    <div>
-                        {{#if (not-eq submission.reviewsState 'pending')}}
-                            {{reviewedOnLabel}}
-                        {{/if}}
-                    </div>
+                    {{#if (not-eq submission.reviewsState 'pending')}}
+                        <div>{{reviewedOnLabel}}</div>
+                    {{/if}}
                 </div>
             </div>
         </div>

--- a/app/components/moderation-list-row/template.hbs
+++ b/app/components/moderation-list-row/template.hbs
@@ -7,16 +7,20 @@
             <div title={{submission.title}} class="submission-info">
                 <div class="submission-title">{{submission.title}}</div>
                 <div class="submission-body">
-                    {{pendingStatusTimeDate}}
-                    {{#each firstContributors as |contributor| ~}}
-                        <li>{{contributor.users.fullName}}</li>
-                    {{/each}}
-                    {{#if (gt additionalContributors 0)}}
-                        + {{additionalContributors}}
-                    {{/if}}
-                    {{#if (not-eq submission.reviewsState 'pending')}}
-                        {{acceptedRejectedStatusTimeDate}}
-                    {{/if}}
+                    <div>
+                        {{submittedOnLabel}}
+                        {{#each firstContributors as |contributor| ~}}
+                            <li>{{contributor.users.fullName}}</li>
+                        {{/each}}
+                        {{#if (gt additionalContributors 0)}}
+                            + {{additionalContributors}}
+                        {{/if}}
+                    </div>
+                    <div>
+                        {{#if (not-eq submission.reviewsState 'pending')}}
+                            {{reviewedOnLabel}}
+                        {{/if}}
+                    </div>
                 </div>
             </div>
         </div>

--- a/app/components/moderation-list-row/template.hbs
+++ b/app/components/moderation-list-row/template.hbs
@@ -7,16 +7,15 @@
             <div title={{submission.title}} class="submission-info">
                 <div class="submission-title">{{submission.title}}</div>
                 <div class="submission-body">
-                    {{#if (eq submission.reviewsState 'pending')}}
-                        {{statusTimeDate}}
-                        {{#each firstContributors as |contributor| ~}}
-                            <li>{{contributor.users.fullName}}</li>
-                        {{/each}}
-                        {{#if (gt additionalContributors 0)}}
-                            + {{additionalContributors}}
-                        {{/if}}
-                    {{else}}
-                        {{statusTimeDate}}
+                    {{pendingStatusTimeDate}}
+                    {{#each firstContributors as |contributor| ~}}
+                        <li>{{contributor.users.fullName}}</li>
+                    {{/each}}
+                    {{#if (gt additionalContributors 0)}}
+                        + {{additionalContributors}}
+                    {{/if}}
+                    {{#if (not-eq submission.reviewsState 'pending')}}
+                        {{acceptedRejectedStatusTimeDate}}
                     {{/if}}
                 </div>
             </div>

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -212,14 +212,14 @@ export default {
         },
         moderationListRow: {
             submission: {
-                submittedOn: 'submitted on {{timeDate}} by',
-                submitted: 'submitted {{timeDate}} by',
-                acceptedOn: 'accepted on {{timeDate}} by {{moderatorName}}',
-                accepted: 'accepted {{timeDate}} by {{moderatorName}}',
-                acceptedAutomaticallyOn: 'accepted automatically on {{timeDate}}',
-                acceptedAutomatically: 'accepted automatically {{timeDate}}',
-                rejectedOn: 'rejected on {{timeDate}} by {{moderatorName}}',
-                rejected: 'rejected {{timeDate}} by {{moderatorName}}',
+                submittedOn: 'Submitted on {{timeDate}} by {{contributorName}}',
+                submitted: 'Submitted {{timeDate}} by {{contributorName}}',
+                acceptedOn: 'Accepted on {{timeDate}} by {{moderatorName}}',
+                accepted: 'Accepted {{timeDate}} by {{moderatorName}}',
+                acceptedAutomaticallyOn: 'Accepted automatically on {{timeDate}}',
+                acceptedAutomatically: 'Accepted automatically {{timeDate}}',
+                rejectedOn: 'Rejected on {{timeDate}} by {{moderatorName}}',
+                rejected: 'Rejected {{timeDate}} by {{moderatorName}}',
             },
         },
         preprintStatusBanner: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -212,8 +212,8 @@ export default {
         },
         moderationListRow: {
             submission: {
-                submittedOn: 'Submitted on {{timeDate}} by {{contributorName}}',
-                submitted: 'Submitted {{timeDate}} by {{contributorName}}',
+                submittedOn: 'Submitted on {{timeDate}} by',
+                submitted: 'Submitted {{timeDate}} by',
                 acceptedOn: 'Accepted on {{timeDate}} by {{moderatorName}}',
                 accepted: 'Accepted {{timeDate}} by {{moderatorName}}',
                 acceptedAutomaticallyOn: 'Accepted automatically on {{timeDate}}',

--- a/tests/integration/components/moderation-list-row/component-test.js
+++ b/tests/integration/components/moderation-list-row/component-test.js
@@ -9,7 +9,7 @@ moduleForComponent('moderation-list-row', 'Integration | Component | moderation-
 
 test('it renders moderation-list-row accepted with actions', function(assert) {
     this.set('submission', {
-        dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        dateCreated: '2017-10-27T19:14:27.816946Z',
         actions: [
             EmberObject.create({
                 fromState: 'pending',
@@ -25,30 +25,38 @@ test('it renders moderation-list-row accepted with actions', function(assert) {
             }),
         ],
         reviewsState: 'accepted',
-        node: EmberObject.create({ contributors: ['Viper', 'Oogway'] }),
+        node: EmberObject.create({
+            contributors: [{ users: { fullName: 'Viper' } }, { users: { fullName: 'Oogway' } }],
+        }),
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
     assert.ok(this.$('[data-status=accepted]').length);
     assert.notOk(this.$('[data-status=pending]').length);
     assert.notOk(this.$('[data-status=rejected]').length);
 
-    assert.equal(this.$('[data-status=accepted]').text().trim(), 'accepted on October 27, 2017 by Kung-fu Panda');
+    assert.equal(this.$('[data-status=accepted]').text().replace(/\s+/g, ' ').trim(), 'Submitted 2 months ago by' +
+        ' Viper Oogway Accepted Invalid date by Kung-fu Panda');
 });
 
 test('it renders moderation-list-row accepted without actions', function(assert) {
     this.set('submission', {
+        dateCreated: '2017-10-27T19:14:27.816946Z',
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
         actions: [],
         reviewsState: 'accepted',
-        node: EmberObject.create({ contributors: ['Tigerss', 'Crane'] }),
+        node: EmberObject.create({
+            contributors: [{ users: { fullName: 'Viper' } }],
+        }),
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
-    assert.equal(this.$('[data-status=accepted]').text().trim(), 'accepted automatically on October 27, 2017');
+    assert.equal(this.$('[data-status=accepted]').text().replace(/\s+/g, ' ').trim(), 'Submitted on October 27, 2017 by Viper' +
+        ' Accepted automatically on October 27, 2017');
 });
 
 test('it renders moderation-list-row rejected with actions', function(assert) {
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        dateCreated: '2017-10-27T19:14:27.816946Z',
         actions: [
             EmberObject.create({
                 fromState: 'pending',
@@ -64,15 +72,19 @@ test('it renders moderation-list-row rejected with actions', function(assert) {
             }),
         ],
         reviewsState: 'rejected',
-        node: EmberObject.create({ contributors: ['Mr. Ping', 'Mantis'] }),
+        node: EmberObject.create({
+            contributors: [{ users: { fullName: 'Mr. Ping' } }],
+        }),
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
-    assert.equal(this.$('[data-status=rejected]').text().trim(), 'rejected on October 27, 2017 by Master Shifu');
+    assert.equal(this.$('[data-status=rejected]').text().replace(/\s+/g, ' ').trim(), 'Submitted on October 27, 2017 by Mr. Ping ' +
+        'Rejected on October 27, 2017 by Master Shifu');
 });
 
 test('it renders moderation-list-row pending with actions', function(assert) {
     this.set('submission', {
-        dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        dateLastTransitioned: '2017-10-26T19:14:27.816946Z',
+        dateCreated: '2017-10-26T19:14:27.816946Z',
         actions: [
             EmberObject.create({
                 fromState: 'initial',
@@ -87,12 +99,13 @@ test('it renders moderation-list-row pending with actions', function(assert) {
         }),
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
-    assert.equal(this.$('[data-status=pending]').text().replace(/\n/g, ' ').trim(), 'submitted on October 27, 2017 by Mr. Ping Mantis');
+    assert.equal(this.$('[data-status=pending]').text().replace(/\s+/g, ' ').trim(), 'Submitted on October 26, 2017 by Mr. Ping Mantis');
 });
 
 test('it renders moderation-list-row pending with actions and more than three contributors', function(assert) {
     this.set('submission', {
-        dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        dateLastTransitioned: '2017-12-26T19:14:27.816946Z',
+        dateCreated: '2017-12-26T19:14:27.816946Z',
         actions: [
             EmberObject.create({
                 fromState: 'initial',
@@ -119,5 +132,5 @@ test('it renders moderation-list-row pending with actions and more than three co
         },
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
-    assert.equal(this.$('[data-status=pending]').text().replace(/\s+/g, ' ').trim(), 'submitted on October 27, 2017 by Mr. Ping Mantis Crane + 1');
+    assert.equal(this.$('[data-status=pending]').text().replace(/\s+/g, ' ').trim(), 'Submitted a few seconds ago by Mr. Ping Mantis Crane + 1');
 });

--- a/tests/integration/components/moderation-list-row/component-test.js
+++ b/tests/integration/components/moderation-list-row/component-test.js
@@ -34,14 +34,14 @@ test('it renders moderation-list-row accepted with reviewActions', function(asse
     assert.notOk(this.$('[data-status=pending]').length);
     assert.notOk(this.$('[data-status=rejected]').length);
 
-    assert.equal(this.$('[data-status=accepted]').text().replace(/\s+/g, ' ').trim(), 'Submitted 2 months ago by' +
+    assert.equal(this.$('[data-status=accepted]').text().replace(/\s+/g, ' ').trim(), 'Submitted on October 27, 2017 by' +
         ' Viper Oogway Accepted Invalid date by Kung-fu Panda');
 });
 
 test('it renders moderation-list-row accepted without reviewActions', function(assert) {
     this.set('submission', {
         dateCreated: '2017-10-27T19:14:27.816946Z',
-        dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        dateLastTransitioned: '2017-10-28T19:14:27.816946Z',
         reviewActions: [],
         reviewsState: 'accepted',
         node: EmberObject.create({
@@ -50,14 +50,14 @@ test('it renders moderation-list-row accepted without reviewActions', function(a
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
     assert.equal(this.$('[data-status=accepted]').text().replace(/\s+/g, ' ').trim(), 'Submitted on October 27, 2017 by Viper' +
-        ' Accepted automatically on October 27, 2017');
+        ' Accepted automatically on October 28, 2017');
 });
 
 test('it renders moderation-list-row rejected with reviewActions', function(assert) {
     this.set('submission', {
-        dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        dateLastTransitioned: '2017-10-28T19:14:27.816946Z',
         dateCreated: '2017-10-27T19:14:27.816946Z',
-            reviewActions: [
+        reviewActions: [
             EmberObject.create({
                 fromState: 'pending',
                 toState: 'rejected',
@@ -78,7 +78,7 @@ test('it renders moderation-list-row rejected with reviewActions', function(asse
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
     assert.equal(this.$('[data-status=rejected]').text().replace(/\s+/g, ' ').trim(), 'Submitted on October 27, 2017 by Mr. Ping ' +
-        'Rejected on October 27, 2017 by Master Shifu');
+        'Rejected on October 28, 2017 by Master Shifu');
 });
 
 test('it renders moderation-list-row pending with reviewActions', function(assert) {
@@ -132,5 +132,5 @@ test('it renders moderation-list-row pending with reviewActions and more than th
         },
     });
     this.render(hbs`{{moderation-list-row submission=submission}}`);
-    assert.equal(this.$('[data-status=pending]').text().replace(/\s+/g, ' ').trim(), 'Submitted a few seconds ago by Mr. Ping Mantis Crane + 1');
+    assert.equal(this.$('[data-status=pending]').text().replace(/\s+/g, ' ').trim(), 'Submitted on December 26, 2017 by Mr. Ping Mantis Crane + 1');
 });

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -287,12 +287,6 @@ test('fileDownloadURL computed property', function (assert) {
     const ctrl = this.subject();
 
     run(() => {
-        const origin = 'http://localhost:4200';
-
-        const window = { location: { origin } };
-
-        ctrl.set('window', window);
-
         const node = this.store.createRecord('node', {
             description: 'test description',
         });
@@ -302,6 +296,8 @@ test('fileDownloadURL computed property', function (assert) {
         ctrl.setProperties({ preprint });
         ctrl.set('preprint.id', '6gtu');
 
-        assert.strictEqual(ctrl.get('fileDownloadURL'), 'http://localhost:4201/6gtu/download');
+        const { location: { origin } } = window;
+
+        assert.strictEqual(ctrl.get('fileDownloadURL'), `${origin}/6gtu/download`);
     });
 });


### PR DESCRIPTION
## Goal
In the rejected/accepted section on the moderation list view, add submitted by along with the accepted by/rejected by.
"submission by <CONTRIBUTORS (3)> was <accepted|rejected> on <DATE> by <MODERATOR>"

WHY:
In demo of accepted/rejected by we discussed recent feedback from users that requested the submitted by author name should also be there.

## Changes

- Update 'moderation list row' component, css, and related translations
- Update component integration and unit tests

![image](https://user-images.githubusercontent.com/11130339/34266089-0be4fa5e-e646-11e7-874f-59c939ac37d1.png)

![image](https://user-images.githubusercontent.com/11130339/34266101-137ba240-e646-11e7-9bc2-2c0b9798eda6.png)


## Ticket
https://openscience.atlassian.net/browse/MOD-191