### PR TITLE
[MOD-202][Fix] Make sure the domain has a trailing slash

### DIFF
--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -38,7 +38,7 @@ export default Service.extend({
                 baseURL += `${this.get('provider.id')}/`;
             }
         } else {
-            baseURL = this.get('domain');
+            baseURL = this.get('domain').replace(/\/?$/, '/');
         }
         return baseURL;
     }),


### PR DESCRIPTION
## Purpose
If the domain for a provider in the admin interface doesn't have a trailing slash it would cause invalid links for branded preprint providers in navbar.

## Changes
Make sure that the domain has a trailing slash when building the links.

## QA Notes

1. In the admin interface on staging, find or edit a provider that has a trailing slash on the url in the domain field.
2. Go to https://staging.osf.io/reviews/preprints/<provider_name> where <provider_name> is the provider that doesn't have the trailing slash.
3. Confirm that the links to "Search" and "Add a Preprint" are correct in the navbar (by clicking on them or hovering)
4. Repeat for a provider that does have a trailing slash in the domain url.