### PR TITLE
[IN-59][Reviews] No redirection if going to a valid route with no permissions

### DIFF
--- a/app/controllers/preprints/provider.js
+++ b/app/controllers/preprints/provider.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+
+export default Controller.extend({
+    hasPermission: computed('model.permissions', function () {
+        return this.get('model.permissions').includes('view_submissions');
+    }),
+});

--- a/app/controllers/preprints/provider/moderation.js
+++ b/app/controllers/preprints/provider/moderation.js
@@ -26,10 +26,6 @@ export default Controller.extend(Analytics, moderationQueryParams.Mixin, {
     store: service(),
     theme: service(),
 
-    hasPermission: computed('model', function () {
-        return this.get('model.permissions').includes('view_submissions');
-    }),
-
     actions: {
         statusChanged(status) {
             this.resetQueryParams(['page']);

--- a/app/controllers/preprints/provider/moderation.js
+++ b/app/controllers/preprints/provider/moderation.js
@@ -1,3 +1,4 @@
+import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 
@@ -5,7 +6,6 @@ import QueryParams from 'ember-parachute';
 import { task } from 'ember-concurrency';
 
 import Analytics from 'ember-osf/mixins/analytics';
-
 
 export const moderationQueryParams = new QueryParams({
     page: {
@@ -25,6 +25,10 @@ export const moderationQueryParams = new QueryParams({
 export default Controller.extend(Analytics, moderationQueryParams.Mixin, {
     store: service(),
     theme: service(),
+
+    hasPermission: computed('model', function () {
+        return this.get('model.permissions').includes('view_submissions');
+    }),
 
     actions: {
         statusChanged(status) {

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -94,6 +94,8 @@ export default Controller.extend({
             .replace(/\s+\S*$/, '');
     }),
 
+    hasPermission: false,
+
     actions: {
         toggleShowLicense() {
             this.toggleProperty('showLicense');
@@ -157,6 +159,8 @@ export default Controller.extend({
 
         // required for breadcrumbs
         this.set('model.breadcrumbTitle', response.get('title'));
+        let hasPermission = this.get('preprint.providers.permissions').include('view_submissions');
+        this.set('hasPermission', hasPermission);
     }),
 
     loadMathJax: task(function* () {

--- a/app/controllers/preprints/provider/setup.js
+++ b/app/controllers/preprints/provider/setup.js
@@ -20,6 +20,10 @@ export default Controller.extend({
         return settings;
     }),
 
+    hasPermission: computed('model.permissions', function () {
+        return this.get('model.permissions').includes('set_up_moderation');
+    }),
+
     actions: {
         cancel() {
             this.transitionToRoute('index');

--- a/app/routes/preprints/provider.js
+++ b/app/routes/preprints/provider.js
@@ -19,9 +19,7 @@ export default Route.extend({
     },
 
     afterModel(model, transition) {
-        if (!model.get('permissions').includes('view_submissions')) {
-            this.replaceWith('forbidden');
-        } else if (!model.get('reviewsWorkflow') && transition.targetName !== 'preprints.provider.setup') {
+        if (!model.get('reviewsWorkflow') && transition.targetName !== 'preprints.provider.setup') {
             this.replaceWith('preprints.provider.setup', model);
         }
     },

--- a/app/routes/preprints/provider/setup.js
+++ b/app/routes/preprints/provider/setup.js
@@ -2,9 +2,7 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
     afterModel(model/* , transition */) {
-        if (!model.get('permissions').contains('set_up_moderation')) {
-            this.replaceWith('index');
-        } else if (model.get('reviewsWorkflow')) {
+        if (model.get('reviewsWorkflow')) {
             this.replaceWith('preprints.provider', model);
         }
     },

--- a/app/templates/preprints/provider.hbs
+++ b/app/templates/preprints/provider.hbs
@@ -1,2 +1,6 @@
-{{moderation-base}}
-{{outlet}}
+{{#if hasPermission}}
+    {{moderation-base}}
+    {{outlet}}
+{{else}}
+    {{error-page error='forbidden'}}
+{{/if}}

--- a/app/templates/preprints/provider.hbs
+++ b/app/templates/preprints/provider.hbs
@@ -1,4 +1,4 @@
-{{#if hasPermission}}
+{{#if hasPermission }}
     {{moderation-base}}
     {{outlet}}
 {{else}}

--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -1,164 +1,168 @@
-<div class="content">
+{{#if hasPermission}}
+    <div class="content">
 
-    <div class="p-t-sm p-b-md m-b-md dark-overlay-header-background">
-        <div class="container">
-            <div class="row">
-                <div class="col-xs-12 col-sm-11">
-                    {{#if fetchData.isIdle}}
-                        {{reviews-breadcrumbs}}
-                        <h1 id="preprintTitle" class="p-t-md p-b-md">{{node.title}}</h1>
-                        <h5>{{contributor-list node=node contributors=preprint.contributors}}</h5>
-                        <h6 class="preprint-added-on">
-                            {{t actionDateLabel}}: {{moment-format preprint.dateLastTransitioned "MMMM DD, YYYY"}} | {{t "content.header.lastEdited"}}: {{moment-format preprint.dateModified "MMMM DD, YYYY"}}
-                        </h6>
-                    {{/if}}
+        <div class="p-t-sm p-b-md m-b-md dark-overlay-header-background">
+            <div class="container">
+                <div class="row">
+                    <div class="col-xs-12 col-sm-11">
+                        {{#if fetchData.isIdle}}
+                            {{reviews-breadcrumbs}}
+                            <h1 id="preprintTitle" class="p-t-md p-b-md">{{node.title}}</h1>
+                            <h5>{{contributor-list node=node contributors=preprint.contributors}}</h5>
+                            <h6 class="preprint-added-on">
+                                {{t actionDateLabel}}: {{moment-format preprint.dateLastTransitioned "MMMM DD, YYYY"}} | {{t "content.header.lastEdited"}}: {{moment-format preprint.dateModified "MMMM DD, YYYY"}}
+                            </h6>
+                        {{/if}}
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    {{#if fetchData.isRunning}}
-        <div class="preprint-status-component preprint-status-component--skeleton"></div>
-    {{else}}
-        {{preprint-status-banner submission=preprint saving=savingAction submitDecision=(action 'submitDecision')}}
-    {{/if}}
+        {{#if fetchData.isRunning}}
+            <div class="preprint-status-component preprint-status-component--skeleton"></div>
+        {{else}}
+            {{preprint-status-banner submission=preprint saving=savingAction submitDecision=(action 'submitDecision')}}
+        {{/if}}
 
-    <div class="view-page">
-        <div class="container">
-            <div class="row p-md">
-                <div id="mfr-col" class="col-md-{{if fullScreenMFR '12' '7'}}">
-                    {{#if fetchData.isRunning}}
-                        {{file-renderer-skeleton}}
-                    {{else}}
-                        {{#if preprint.isPreprintOrphan}}
-                            <div class="alert alert-danger m-r-md" role="alert">
-                                {{t "content.orphan_preprint"}}
-                            </div>
+        <div class="view-page">
+            <div class="container">
+                <div class="row p-md">
+                    <div id="mfr-col" class="col-md-{{if fullScreenMFR '12' '7'}}">
+                        {{#if fetchData.isRunning}}
+                            {{file-renderer-skeleton}}
                         {{else}}
-                            {{preprint-file-browser primaryFile=preprint.primaryFile preprint=preprint chooseFile=(action 'chooseFile')}}
-                        {{/if}}
-                    {{/if}}
-                    <button class="expand-mfr-carrot hidden-xs hidden-sm" {{action 'expandMFR'}}>
-                        <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
-                    </button>
-                </div>
-
-                <div class="col-md-5 {{if fullScreenMFR 'hidden' ''}}">
-                    {{#if fetchData.isRunning}}
-                        {{#content-placeholders as |placeholder|}}
-                            {{placeholder.img}}
-                            {{#each dummyMetaData}}
-                                <div class="m-v-lg">
-                                    {{placeholder.heading subtitle=false}}
-                                    {{placeholder.text lines=2}}
+                            {{#if preprint.isPreprintOrphan}}
+                                <div class="alert alert-danger m-r-md" role="alert">
+                                    {{t "content.orphan_preprint"}}
                                 </div>
-                            {{/each}}
-                        {{/content-placeholders}}
-                    {{else}}
-                        <div class="share-row p-sm osf-box-lt clearfix">
-                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}}>
-                                {{t "content.share.downloadPreprint"}}
-                            </a>
-                            <div class="p-v-xs pull-right">
-                                {{t "content.share.downloads"}}: {{preprint.primaryFile.extra.downloads}}
-                            </div>
-                        </div>
-
-                        <div class="p-t-md pull-right">
-                            <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-twitter-square"></i>
-                            </a>
-                            <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-facebook-square"></i>
-                            </a>
-                            <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-linkedin-square"></i>
-                            </a>
-                            <a class="text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-envelope"></i>
-                            </a>
-                        </div>
-
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
-                            <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
-                                {{~if useShortenedDescription description node.description~}}
-                            </p>
-                            <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
-                                {{~t (if expandedAbstract 'content.seeLess' 'content.seeMore')~}}
-                            </button>
-                        </div>
-
-                        <section class="p-t-xs">
-                            {{#if preprint.preprintDoiUrl}}
-                                <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI"}}</strong></h4>
-                                <a href={{preprint.preprintDoiUrl}}>{{extract-doi preprint.preprintDoiUrl}}</a>
-                            {{else if (not preprint.isPublished)}}
-                                <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI"}}</strong></h4>
-                                {{t 'content.preprintPendingDOI'}}
-                            {{/if}}
-                        </section>
-
-                        {{#if preprint.articleDoiUrl}}
-                            <section class="p-t-xs">
-                                <h4 class="p-v-md f-w-md"><strong>{{t "content.articleDOI"}}</strong></h4>
-                                <a href={{preprint.articleDoiUrl}}>{{preprint.doi}}</a>
-                            </section>
-                        {{/if}}
-
-                        {{#if preprint.license.name}}
-                            <section class="preprint-license p-t-xs">
-                                <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
-                                {{preprint.license.name}}
-                                <span  onclick={{action 'toggleShowLicense'}} role="button">
-                                    <i class="fa fa-caret-{{if showLicense 'down' 'right'}}"></i>
-                                </span>
-                                {{#if showLicense}}
-                                    <pre>{{preprint.licenseText}}</pre>
-                                {{/if}}
-                            </section>
-                        {{/if}}
-
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
-                            {{#each preprint.uniqueSubjects as |subject|}}
-                                <span class='subject-preview'>{{subject.text}}</span>
-                            {{/each}}
-                        </div>
-
-                        <div class="p-t-xs">
-                            <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
-                            {{#if hasTags}}
-                                {{#each node.tags as |tag|}}
-                                    <span class="badge">{{fix-special-char tag}}</span>
-                                {{/each}}
                             {{else}}
-                                {{t "global.none"}}
+                                {{preprint-file-browser primaryFile=preprint.primaryFile preprint=preprint chooseFile=(action 'chooseFile')}}
                             {{/if}}
-                        </div>
+                        {{/if}}
+                        <button class="expand-mfr-carrot hidden-xs hidden-sm" {{action 'expandMFR'}}>
+                            <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
+                        </button>
+                    </div>
 
-                        <div class="p-t-xs m-b-lg">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.citations"}}</strong></h4>
-                            {{citation-widget node=preprint}}
-                        </div>
-
-                        <div class="p-lg osf-box-lt row project-box">
-                            <div class="col-xs-6 text-center">
-                                <div class="content-provider-logo provider-osf-dark"
-                                     title={{t "global.openScienceFramework"}}></div>
+                    <div class="col-md-5 {{if fullScreenMFR 'hidden' ''}}">
+                        {{#if fetchData.isRunning}}
+                            {{#content-placeholders as |placeholder|}}
+                                {{placeholder.img}}
+                                {{#each dummyMetaData}}
+                                    <div class="m-v-lg">
+                                        {{placeholder.heading subtitle=false}}
+                                        {{placeholder.text lines=2}}
+                                    </div>
+                                {{/each}}
+                            {{/content-placeholders}}
+                        {{else}}
+                            <div class="share-row p-sm osf-box-lt clearfix">
+                                <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}}>
+                                    {{t "content.share.downloadPreprint"}}
+                                </a>
+                                <div class="p-v-xs pull-right">
+                                    {{t "content.share.downloads"}}: {{preprint.primaryFile.extra.downloads}}
+                                </div>
                             </div>
-                            <div class="col-xs-6 text-left">
-                                <p class="f-w-xs">{{t "content.projectButton.paragraph"}}</p>
-                                <a type="button" class="btn btn-info" href={{node.links.html}}>
-                                    {{t "content.projectButton.button"}}
+
+                            <div class="p-t-md pull-right">
+                                <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-twitter-square"></i>
+                                </a>
+                                <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-facebook-square"></i>
+                                </a>
+                                <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-linkedin-square"></i>
+                                </a>
+                                <a class="text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-envelope"></i>
                                 </a>
                             </div>
-                        </div>
-                    {{/if}}
-                </div>
 
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
+                                <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
+                                    {{~if useShortenedDescription description node.description~}}
+                                </p>
+                                <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
+                                    {{~t (if expandedAbstract 'content.seeLess' 'content.seeMore')~}}
+                                </button>
+                            </div>
+
+                            <section class="p-t-xs">
+                                {{#if preprint.preprintDoiUrl}}
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI"}}</strong></h4>
+                                    <a href={{preprint.preprintDoiUrl}}>{{extract-doi preprint.preprintDoiUrl}}</a>
+                                {{else if (not preprint.isPublished)}}
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI"}}</strong></h4>
+                                    {{t 'content.preprintPendingDOI'}}
+                                {{/if}}
+                            </section>
+
+                            {{#if preprint.articleDoiUrl}}
+                                <section class="p-t-xs">
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "content.articleDOI"}}</strong></h4>
+                                    <a href={{preprint.articleDoiUrl}}>{{preprint.doi}}</a>
+                                </section>
+                            {{/if}}
+
+                            {{#if preprint.license.name}}
+                                <section class="preprint-license p-t-xs">
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
+                                    {{preprint.license.name}}
+                                    <span  onclick={{action 'toggleShowLicense'}} role="button">
+                                    <i class="fa fa-caret-{{if showLicense 'down' 'right'}}"></i>
+                                </span>
+                                    {{#if showLicense}}
+                                        <pre>{{preprint.licenseText}}</pre>
+                                    {{/if}}
+                                </section>
+                            {{/if}}
+
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
+                                {{#each preprint.uniqueSubjects as |subject|}}
+                                    <span class='subject-preview'>{{subject.text}}</span>
+                                {{/each}}
+                            </div>
+
+                            <div class="p-t-xs">
+                                <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
+                                {{#if hasTags}}
+                                    {{#each node.tags as |tag|}}
+                                        <span class="badge">{{fix-special-char tag}}</span>
+                                    {{/each}}
+                                {{else}}
+                                    {{t "global.none"}}
+                                {{/if}}
+                            </div>
+
+                            <div class="p-t-xs m-b-lg">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.citations"}}</strong></h4>
+                                {{citation-widget node=preprint}}
+                            </div>
+
+                            <div class="p-lg osf-box-lt row project-box">
+                                <div class="col-xs-6 text-center">
+                                    <div class="content-provider-logo provider-osf-dark"
+                                         title={{t "global.openScienceFramework"}}></div>
+                                </div>
+                                <div class="col-xs-6 text-left">
+                                    <p class="f-w-xs">{{t "content.projectButton.paragraph"}}</p>
+                                    <a type="button" class="btn btn-info" href={{node.links.html}}>
+                                        {{t "content.projectButton.button"}}
+                                    </a>
+                                </div>
+                            </div>
+                        {{/if}}
+                    </div>
+
+                </div>
             </div>
         </div>
-    </div>
 
-</div>
+    </div>
+{{else}}
+    {{error-page error='forbidden'}}
+{{/if}}

--- a/app/templates/preprints/provider/setup.hbs
+++ b/app/templates/preprints/provider/setup.hbs
@@ -1,39 +1,43 @@
-<div class="reviews-setup">
-    <header>
-        <div class="container">
-            <div class="row">
-                <div class="text-center col-xs-12">
-                    <h1>{{t "setup.chooseSettings" provider=model.name}}</h1>
+{{#if hasPermission}}
+    <div class="reviews-setup">
+        <header>
+            <div class="container">
+                <div class="row">
+                    <div class="text-center col-xs-12">
+                        <h1>{{t "setup.chooseSettings" provider=model.name}}</h1>
+                    </div>
                 </div>
             </div>
+        </header>
+
+        <div class="text-bigger alert alert-warning text-center">
+            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+            {{t "setup.onceFinalized"}}
         </div>
-    </header>
 
-    <div class="text-bigger alert alert-warning text-center">
-        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-        {{t "setup.onceFinalized"}}
+        <div class="container">
+            <form class="row m-t-lg">
+                {{#each providerSettings as |setting|}}
+                    {{#form-block title=setting.title description=setting.description disabled=setting.disabled}}
+                        {{#each setting.options as |option|}}
+                            {{form-block-radiobutton
+                            title=option.title
+                            description=option.description
+                            name=setting.attributeName
+                            value=option.value
+                            attribute=(mut (get this setting.attributeName))
+                            }}
+                        {{/each}}
+                    {{/form-block}}
+                {{/each}}
+
+                <div class="m-t-lg btn-toolbar pull-right">
+                    <button class="btn btn-default" {{action "cancel"}}>{{t "global.cancel"}}</button>
+                    <button class="btn btn-success" {{action "submit"}}>{{t "setup.finalize"}}</button>
+                </div>
+            </form>
+        </div>
     </div>
-
-    <div class="container">
-        <form class="row m-t-lg">
-            {{#each providerSettings as |setting|}}
-                {{#form-block title=setting.title description=setting.description disabled=setting.disabled}}
-                    {{#each setting.options as |option|}}
-                        {{form-block-radiobutton
-                        title=option.title
-                        description=option.description
-                        name=setting.attributeName
-                        value=option.value
-                        attribute=(mut (get this setting.attributeName))
-                        }}
-                    {{/each}}
-                {{/form-block}}
-            {{/each}}
-
-            <div class="m-t-lg btn-toolbar pull-right">
-                <button class="btn btn-default" {{action "cancel"}}>{{t "global.cancel"}}</button>
-                <button class="btn btn-success" {{action "submit"}}>{{t "setup.finalize"}}</button>
-            </div>
-        </form>
-    </div>
-</div>
+{{else}}
+    {{error-page error='forbidden'}}
+{{/if}}


### PR DESCRIPTION
## Purpose

Currently, when a user who has no permission to the moderation page of a certain provider, we redirect them to `/reviews/forbidden`. This PR change the behavior so that we do not redirect, but still show a "Forbidden" page.

## Summary of Changes

In `routes/preprints/provider.js`, we no longer check for user permission but delegate that duty to the controller.
In `moderation.js` controller, a computed value `hasPermission` is added to check whether a user has permission for the current view.
In `templates/preprints/provider.hbs`, conditional is added to render "Forbidden" page if user has no permissions.

## Side Effects / Testing Notes

Check that if a user has no permission to a certain provider's moderation page (`reviews/preprints/<provider_id>`), instead of redirecting to `reviews/forbidden` to show the forbidden page, it should still show the "Forbidden" page but staying at `reviews/preprints/<provider_id>`.

## Ticket

https://openscience.atlassian.net/browse/IN-59