### PR TITLE
[IN-57][Fix] Use primary color for button

### DIFF
--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -167,8 +167,8 @@
         {{/modal.header}}
         {{#modal.body}}<div class="warning-body">{{t 'content.warning.body'}}</div>{{/modal.body}}
         {{#modal.footer}}
-            {{#bs-button onClick=(action modal.close) type="info"}}{{t 'content.warning.footer.stay'}}{{/bs-button}}
-            {{#bs-button onClick=(action 'leavePage')}}{{t 'content.warning.footer.leave'}}{{/bs-button}}
+            {{#bs-button onClick=(action modal.close)}}{{t 'content.warning.footer.stay'}}{{/bs-button}}
+            {{#bs-button onClick=(action 'leavePage') type="primary"}}{{t 'content.warning.footer.leave'}}{{/bs-button}}
         {{/modal.footer}}
     {{/bs-modal}}
 </div>


### PR DESCRIPTION
## Purpose
To be consistent with default modals on browsers, move the primary button to the right.

## Changes
Change the color of the right button to primary and use default color for the left.

## Side Effects
None

