### PR TITLE
[IN-57][Reviews] Do not show warning on decision submit

### DIFF
--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -33,7 +33,8 @@ export default Route.extend(ConfirmationMixin, {
             }
         },
         willTransition(transition) {
-            if (this.isPageDirty()) {
+            const allow = this.shouldCheckIsPageDirty(transition);
+            if (!allow && this.isPageDirty()) {
                 this.controller.set('showWarning', true);
                 this.controller.set('previousTransition', transition);
                 transition.abort();
@@ -45,5 +46,23 @@ export default Route.extend(ConfirmationMixin, {
         // If true, shows a confirmation message when leaving the page
         // True if the reviewer has any unsaved changes including comment edit or state change.
         return this.controller.get('userHasEnteredReview');
+    },
+
+    shouldCheckIsPageDirty(transition) {
+        // Allows the 'preprints.provider.moderation' route as an exception
+        // to the dirty message upon review decision/comment submit
+        const isChildRouteTransition = this._super(...arguments);
+        const submitRoute = 'preprints.provider.moderation';
+        const savingAction = this.controller.get('savingAction');
+
+        if (transition.targetName === submitRoute) {
+            if (!savingAction) {
+                return isChildRouteTransition;
+            }
+            this.controller.toggleProperty('savingAction');
+            return true;
+        }
+
+        return isChildRouteTransition;
     },
 });


### PR DESCRIPTION
## Purpose

This is a follow-up PR for https://github.com/CenterForOpenScience/ember-osf-reviews/pull/108
 
Fix issue where the user gets a warning modal even after they submit
the decision form.

## Summary of Changes

- Set `userHasEnteredReview` to `false` on `submitDecision` action, hence preventing
the `showWarning` to be set to `true` in `willTransition` action.
- Updated tests

## Side Effects / Testing Notes
On the preprint detail page:

- Change the reviewer's decision
- Without submitting the form, attempt to click on any link on the page; make sure you are prevented from navigating forward and shown the warning modal. On the modal, hit `stay` or `leave` and see if they behave as expected.
- Back to the preprint detail page, modify decision, and submit. You should not get the warning modal.

## Ticket

https://openscience.atlassian.net/browse/IN-57

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
