### PR TITLE
[IN-179][Reviews] Fix URL for download button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Tests for download URL for branded and un-branded providers
+
+### Fixed
+- Download URL on preprint-detail page to work for admin and moderators on pre-moderation
+
 ## [0.3.0] - 2018-01-10
 ### Changed
 - Update `action` to `review-action` to reflect changes in OSF's API and ember-osf

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -27,6 +27,7 @@ export default Controller.extend({
     i18n: service(),
     toast: service(),
     store: service(),
+    theme: service(),
 
     queryParams: { chosenFile: 'file' },
 
@@ -64,6 +65,7 @@ export default Controller.extend({
         const { location: { origin } } = window;
         return [
             origin,
+            this.get('theme.id') !== 'osf' ? `preprints/${this.get('theme.id')}` : null,
             this.get('preprint.id'),
             'download',
         ].filter(part => !!part).join('/');

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -280,18 +280,28 @@ test('submitDecision action', function (assert) {
     });
 });
 
-test('fileDownloadURL computed property', function (assert) {
+test('fileDownloadURL computed property - non-branded provider', function (assert) {
     this.inject.service('store');
     this.inject.service('theme');
+
+    this.theme.id = 'osf';
 
     const ctrl = this.subject();
 
     run(() => {
+        const provider = this.store.createRecord('preprint-provider', {
+            name: 'osf',
+            reviewsWorkflow: 'pre-moderation',
+        });
+
         const node = this.store.createRecord('node', {
             description: 'test description',
         });
 
-        const preprint = this.store.createRecord('preprint', { node });
+        const preprint = this.store.createRecord('preprint', {
+            provider,
+            node,
+        });
 
         ctrl.setProperties({ preprint });
         ctrl.set('preprint.id', '6gtu');
@@ -299,6 +309,38 @@ test('fileDownloadURL computed property', function (assert) {
         const { location: { origin } } = window;
 
         assert.strictEqual(ctrl.get('fileDownloadURL'), `${origin}/6gtu/download`);
+    });
+});
+
+test('fileDownloadURL computed property - branded provider', function(assert) {
+    this.inject.service('store');
+    this.inject.service('theme');
+
+    this.theme.id = 'engrxiv';
+
+    const ctrl = this.subject();
+
+    run(() => {
+        const provider = this.store.createRecord('preprint-provider', {
+            name: 'engrxiv',
+            reviewsWorkflow: 'pre-moderation',
+        });
+
+        const node = this.store.createRecord('node', {
+            description: 'test description',
+        });
+
+        const preprint = this.store.createRecord('preprint', {
+            provider,
+            node,
+        });
+
+        ctrl.setProperties({ preprint });
+        ctrl.set('preprint.id', '6gtu');
+
+        const { location: { origin } } = window;
+
+        assert.strictEqual(ctrl.get('fileDownloadURL'), `${origin}/preprints/engrxiv/6gtu/download`);
     });
 });
 


### PR DESCRIPTION
## Purpose

Whenever a user tries to download a preprint, they are taken to an error page.  The user shouldn't be taken to an error page when doing this (and shouldn't be redirected at all).

## Changes

- Change the download URL to include `/preprints/{provider}`
  (before was `{window.origin}/guid/download`.  Now is `{window.origin}/preprints/{provider}/guid/download`

## QA Notes

This will affect anywhere the user can download the file on the `file-detail` page.  Check that the user can download before/after/approved/rejected moderation and that they don't get any errors.

## Ticket

https://openscience.atlassian.net/browse/IN-179