### PR TITLE
[IN-57][Reviews] Prevent warning on cancel

### DIFF
--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -256,6 +256,7 @@ export default Component.extend({
         cancel() {
             this.set('decision', this.get('submission.reviewsState'));
             this.set('reviewerComment', this.get('initialReviewerComment'));
+            this.get('setUserEnteredReview')(false);
         },
         decisionToggled() {
             this.get('setUserEnteredReview')(this.get('decisionChanged'));

--- a/tests/unit/components/preprint-status-banner-test.js
+++ b/tests/unit/components/preprint-status-banner-test.js
@@ -213,6 +213,8 @@ test('cancel action', function(assert) {
     const component = this.subject();
 
     run(() => {
+        component.set('setUserEnteredReview', () => {});
+
         const node = this.store.createRecord('node', {
             title: 'test title',
             description: 'test description',


### PR DESCRIPTION
## Purpose

User should not get a warning about unsaved changes if they click `Cancel`

## Summary of Changes

- Set `userHasEnteredReview` to `false` on cancel.

## Side Effects / Testing Notes

Follow up PR to https://github.com/CenterForOpenScience/ember-osf-reviews/pull/112.

## Ticket

[IN-57](https://openscience.atlassian.net/browse/IN-57)