### PR TITLE
[Hotfix][Reviews][IN-179] Fix fileDownloadURL

### DIFF
--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -50,12 +50,12 @@ export default Controller.extend({
         },
     }),
 
-    fileDownloadURL: computed('preprint', function() {
+    fileDownloadURL: computed('model', function() {
         const { location: { origin } } = window;
         return [
             origin,
             this.get('theme.id') !== 'osf' ? `preprints/${this.get('theme.id')}` : null,
-            this.get('preprint.id'),
+            this.get('model.id'),
             'download',
         ].filter(part => !!part).join('/');
     }),

--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -24,7 +24,7 @@
                         {{t "content.orphan_preprint"}}
                     </div>
                 {{else}}
-                    {{preprint-file-browser primaryFile=model.primaryFile preprint=model chooseFile=(action 'chooseFile')}}
+                    {{preprint-file-browser primaryFile=model.primaryFile preprint=model fileDownloadURL=fileDownloadURL chooseFile=(action 'chooseFile')}}
                     <button class="expand-mfr-carrot hidden-xs hidden-sm" {{action 'expandMFR'}}>
                         <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
                     </button>

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -298,13 +298,13 @@ test('fileDownloadURL computed property - non-branded provider', function (asser
             description: 'test description',
         });
 
-        const preprint = this.store.createRecord('preprint', {
+        const model = this.store.createRecord('preprint', {
             provider,
             node,
         });
 
-        ctrl.setProperties({ preprint });
-        ctrl.set('preprint.id', '6gtu');
+        ctrl.setProperties({ model });
+        ctrl.set('model.id', '6gtu');
 
         assert.strictEqual(ctrl.get('fileDownloadURL'), 'http://localhost:4201/6gtu/download');
     });
@@ -328,13 +328,13 @@ test('fileDownloadURL computed property - branded provider', function(assert) {
             description: 'test description',
         });
 
-        const preprint = this.store.createRecord('preprint', {
+        const model = this.store.createRecord('preprint', {
             provider,
             node,
         });
 
-        ctrl.setProperties({ preprint });
-        ctrl.set('preprint.id', '6gtu');
+        ctrl.setProperties({ model });
+        ctrl.set('model.id', '6gtu');
 
         const { location: { origin } } = window;
 


### PR DESCRIPTION
## Purpose
`this.preprint` was not in context, as [the router](https://github.com/CenterForOpenScience/ember-osf-reviews/blob/61f2aec7a74cd10a7abd6012b255c0ecbf25b0ee/app/routes/preprints/provider/preprint-detail.js#L11-L17) defines it as `model`.

## Changes
* Use correct name
* Update tests

## Side effects
None expected