### PR TITLE
[IN-199][Reviews][Hotfix] Set saving to false instead of toggling

### DIFF
--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -144,7 +144,7 @@ export default Controller.extend({
         return action.save()
             .then(this._toModerationList.bind(this, { status: filter, page: 1, sort: '-date_last_transitioned' }))
             .catch(this._notifySubmitFailure.bind(this))
-            .finally(() => this.toggleProperty('savingAction'));
+            .finally(() => this.set('savingAction', false));
     },
 
     _toModerationList(queryParams) {


### PR DESCRIPTION
## Purpose
Allow moderators to change their decision after they submit. If a moderator made a decision and then clicked on the submission again they wouldn't be able to change the decision.

## Changes
Set `saving` to false instead of toggling (we got too toggle happy)

## Testing
Follow the steps reported in the ticket. 

## Ticket
https://openscience.atlassian.net/browse/IN-199