### PR TITLE
[IN-206][Reviews] Fix fileDownloadUrl

### DIFF
--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -66,7 +66,7 @@ export default Controller.extend({
         return [
             origin,
             this.get('theme.id') !== 'osf' ? `preprints/${this.get('theme.id')}` : null,
-            this.get('model.id'),
+            this.get('model.preprintId'),
             'download',
         ].filter(part => !!part).join('/');
     }),

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -304,9 +304,11 @@ test('fileDownloadURL computed property - non-branded provider', function (asser
         });
 
         ctrl.setProperties({ model });
-        ctrl.set('model.id', '6gtu');
+        ctrl.set('model.preprintId', '6gtu');
 
-        assert.strictEqual(ctrl.get('fileDownloadURL'), 'http://localhost:4201/6gtu/download');
+        const { location: { port } } = window;
+
+        assert.strictEqual(ctrl.get('fileDownloadURL'), `http://localhost:${port}/6gtu/download`);
     });
 });
 
@@ -334,7 +336,7 @@ test('fileDownloadURL computed property - branded provider', function(assert) {
         });
 
         ctrl.setProperties({ model });
-        ctrl.set('model.id', '6gtu');
+        ctrl.set('model.preprintId', '6gtu');
 
         const { location: { origin } } = window;
 


### PR DESCRIPTION
## Purpose

Fix issue where moderator cannot download (pending) preprints

## Summary of Changes

- Use`model.preprintId` instead of `model.id` for `fileDownloadUrl` property.
- Update tests

## Side Effects / Testing Notes
This fix affects preprint detail page. The download button should have the guid of the current preprint.

Please test under several scenarios (`pre-moderation, post-moderation`) whether the preprint is pending or decision has been made (`rejected` or `accepted`), `branded` and `non-branded` providers

## Ticket

https://openscience.atlassian.net/browse/IN-206

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
