### PR TITLE
[IN-206][Reviews] Fix warning on preprint download 

### DIFF
--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -126,7 +126,7 @@ export default Controller.extend({
         },
         submitDecision(trigger, comment, filter) {
             this.toggleProperty('savingAction');
-
+            this.set('userHasEnteredReview', false);
             const action = this.store.createRecord('review-action', {
                 actionTrigger: trigger,
                 target: this.get('preprint'),

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -126,7 +126,6 @@ export default Controller.extend({
         },
         submitDecision(trigger, comment, filter) {
             this.toggleProperty('savingAction');
-            this.set('userHasEnteredReview', false);
             const action = this.store.createRecord('review-action', {
                 actionTrigger: trigger,
                 target: this.get('preprint'),
@@ -148,6 +147,7 @@ export default Controller.extend({
     },
 
     _toModerationList(queryParams) {
+        this.set('userHasEnteredReview', false);
         this.transitionToRoute('preprints.provider.moderation', { queryParams });
     },
 

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -33,8 +33,7 @@ export default Route.extend(ConfirmationMixin, {
             }
         },
         willTransition(transition) {
-            const allow = this.shouldCheckIsPageDirty(transition);
-            if (!allow && this.isPageDirty()) {
+            if (this.isPageDirty()) {
                 this.controller.set('showWarning', true);
                 this.controller.set('previousTransition', transition);
                 transition.abort();
@@ -46,23 +45,5 @@ export default Route.extend(ConfirmationMixin, {
         // If true, shows a confirmation message when leaving the page
         // True if the reviewer has any unsaved changes including comment edit or state change.
         return this.controller.get('userHasEnteredReview');
-    },
-
-    shouldCheckIsPageDirty(transition) {
-        // Allows the 'preprints.provider.moderation' route as an exception
-        // to the dirty message upon review decision/comment submit
-        const isChildRouteTransition = this._super(...arguments);
-        const submitRoute = 'preprints.provider.moderation';
-        const savingAction = this.controller.get('savingAction');
-
-        if (transition.targetName === submitRoute) {
-            if (!savingAction) {
-                return isChildRouteTransition;
-            }
-            this.controller.toggleProperty('savingAction');
-            return true;
-        }
-
-        return isChildRouteTransition;
     },
 });

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -271,10 +271,12 @@ test('submitDecision action', function (assert) {
         const stub = this.stub(ctrl, '_saveAction');
 
         ctrl.send('submitDecision', 'accept', 'yes', 'accepted');
+        assert.strictEqual(ctrl.get('userHasEnteredReview'), false);
         assert.strictEqual(ctrl.get('savingAction'), !initialValue);
         assert.ok(stub.calledWithExactly(action, 'accepted'), 'correct arguments passed to _saveAction');
 
         ctrl.send('submitDecision', 'reject', 'no', 'rejected');
+        assert.strictEqual(ctrl.get('userHasEnteredReview'), false);
         assert.strictEqual(ctrl.get('savingAction'), initialValue);
         assert.ok(stub.calledWithExactly(action, 'rejected'), 'correct arguments passed to _saveAction');
     });


### PR DESCRIPTION
## Purpose
 
Fix issue where the user gets a warning modal when attempting
to download preprint after a decision has been submitted.

This issue was caused by `userHasEnteredReview` being left true on decision submission.

## Summary of Changes

- Set `userHasEnteredReview` to `false` on `submitDecision` action, hence preventing
the `showWarning` to be set to `true` in `willTransition` action.
- Updated tests

## Side Effects / Testing Notes
On the preprint detail page:

- Change the reviewer's decision
- Without submitting the form, attempt to click on any link on the page; make sure you are prevented from navigating forward and shown the warning modal. On the modal, hit `stay` or `leave` and see if they behave as expected.
- Back to the preprint detail page, modify decision, and submit. You should not get the warning modal.
- After submitting a decision, attempt to download the preprint.

## Ticket

[IN-206](https://openscience.atlassian.net/browse/IN-206)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
