### PR TITLE
[IN-6][Reviews] Add moderator management page

### DIFF
--- a/app/components/loading-btn-indicator/template.hbs
+++ b/app/components/loading-btn-indicator/template.hbs
@@ -1,0 +1,1 @@
+<i class="fa fa-circle-o-notch fa-spin"></i>

--- a/app/components/moderation-base/component.js
+++ b/app/components/moderation-base/component.js
@@ -21,10 +21,14 @@ export default Component.extend({
     tabs: computed('theme.reviewableStatusCounts.pending', function() {
         return [
             {
-                nameKey: 'global.moderation',
+                nameKey: 'global.submissions',
                 route: 'preprints.provider.moderation',
                 hasCount: true,
                 count: this.get('theme.reviewableStatusCounts.pending'),
+            },
+            {
+                nameKey: 'global.moderators',
+                route: 'preprints.provider.moderators',
             },
             {
                 nameKey: 'global.notifications',

--- a/app/components/moderation-base/style.scss
+++ b/app/components/moderation-base/style.scss
@@ -31,7 +31,7 @@
 #tabTitle .nav > li > a {
   border-radius: 0;
   font-size: 24px;
-  padding: 15px 20px;
+  padding: 10px 15px;
 }
 
 #tabTitle .nav > li > a:hover {

--- a/app/components/moderator-list-add/component.js
+++ b/app/components/moderator-list-add/component.js
@@ -1,0 +1,57 @@
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+
+import { task, timeout } from 'ember-concurrency';
+
+
+const DEBOUNCE_MS = 250;
+
+export default Component.extend({
+    i18n: service(),
+    store: service(),
+
+    selectedUser: '',
+
+    role: computed('moderator.permissionGroup', 'roleOptions', function() {
+        for (const value of this.get('roleOptions')) {
+            if (value.role === this.get('moderator.permissionGroup')) {
+                return value.label;
+            }
+        }
+        return 'Role';
+    }),
+
+    disableSave: computed('role', 'user', function() {
+        return this.get('role') === 'Role' || !this.get('selectedUser');
+    }),
+
+    actions: {
+        roleChanged(role) {
+            this.set('role', role);
+        },
+        cancel() {
+            this.setProperties({
+                editingModerator: false,
+                addingNewModerator: false,
+                role: 'Role',
+                selectedUser: '',
+            });
+        },
+    },
+
+    searchUsers: task(function* (query) {
+        yield timeout(DEBOUNCE_MS);
+        try {
+            const users = yield this.get('store').query('user', {
+                filter: {
+                    'full_name,given_name,middle_names,family_name': query,
+                },
+                size: 20,
+            });
+            return users;
+        } catch (e) {
+            this.get('toast').error(this.get('i18n').t('submit.search_contributors_error'));
+        }
+    }).restartable(),
+});

--- a/app/components/moderator-list-add/component.js
+++ b/app/components/moderator-list-add/component.js
@@ -5,8 +5,6 @@ import Component from '@ember/component';
 import { task, timeout } from 'ember-concurrency';
 import { validator, buildValidations } from 'ember-cp-validations';
 
-import config from '../../config/environment';
-
 
 const DEBOUNCE_MS = 250;
 

--- a/app/components/moderator-list-add/component.js
+++ b/app/components/moderator-list-add/component.js
@@ -8,8 +8,9 @@ import { validator, buildValidations } from 'ember-cp-validations';
 
 const DEBOUNCE_MS = 250;
 
-/* Validations for adding unregistered contributor form.  fullName must be present
-and have three letters, and the username (email) must be present and of appropriate format.
+/* Validations for adding unregistered contributor form.
+* fullName must be present and have at least three characters but not more than 255
+* username (email) must be present and of appropriate format.
 */
 const Validations = buildValidations({
     fullName: {
@@ -18,6 +19,7 @@ const Validations = buildValidations({
             validator('presence', true),
             validator('length', {
                 min: 3,
+                max: 255,
             }),
         ],
     },
@@ -109,7 +111,7 @@ export default Component.extend(Validations, {
                     profileImage: user.__data.links.profile_image,
                     id: user.id,
                 };
-                if (this.get('moderatorIds').indexOf(user.id) > -1) {
+                if (this.get('moderatorIds').includes(user.id)) {
                     userData.disabled = true;
                 }
                 return userData;

--- a/app/components/moderator-list-add/component.js
+++ b/app/components/moderator-list-add/component.js
@@ -120,6 +120,7 @@ export default Component.extend(Validations, {
                 const userData = {
                     fullName: user.attributes.full_name,
                     profileImage: user.links.profile_image,
+                    id: user.id,
                 };
                 if (this.get('moderatorIds').indexOf(user.id) > -1) {
                     userData.disabled = true;

--- a/app/components/moderator-list-add/component.js
+++ b/app/components/moderator-list-add/component.js
@@ -12,29 +12,27 @@ export default Component.extend({
     store: service(),
 
     selectedUser: '',
+    roleLabel: 'Role',
+    role: '',
 
-    role: computed('moderator.permissionGroup', 'roleOptions', function() {
-        for (const value of this.get('roleOptions')) {
-            if (value.role === this.get('moderator.permissionGroup')) {
-                return value.label;
-            }
-        }
-        return 'Role';
-    }),
-
-    disableSave: computed('role', 'user', function() {
-        return this.get('role') === 'Role' || !this.get('selectedUser');
+    disableSave: computed('role', 'selectedUser', function() {
+        return !this.get('role') || !this.get('selectedUser');
     }),
 
     actions: {
         roleChanged(role) {
             this.set('role', role);
+            for (const value of this.get('roleOptions')) {
+                if (value.role === role) {
+                    this.set('roleLabel', value.label);
+                }
+            }
         },
         cancel() {
             this.setProperties({
                 editingModerator: false,
                 addingNewModerator: false,
-                role: 'Role',
+                role: '',
                 selectedUser: '',
             });
         },

--- a/app/components/moderator-list-add/component.js
+++ b/app/components/moderator-list-add/component.js
@@ -38,16 +38,20 @@ export default Component.extend(Validations, {
     store: service(),
 
     selectedUser: '',
-    selectedUnregisteredUser: '',
+    unregisteredUserName: '',
+    unregisteredUserEmail: '',
+    selectedUnregisteredUser: false,
     roleLabel: 'Role',
     role: '',
-    fullName: null,
-    email: null,
 
     isFormValid: computed.alias('validations.isValid'),
 
-    disableSave: computed('role', 'selectedUser', function() {
-        return !this.get('role') || !this.get('selectedUser');
+    selectedUserId: computed('selectedUser', 'unregisteredUserEmail', function() {
+        return this.get('selectedUser.id') || this.get('unregisteredUserEmail');
+    }),
+
+    disableSave: computed('role', 'selectedUser', 'unregisteredUserName', function() {
+        return !this.get('role') || (!this.get('selectedUser') && !this.get('unregisteredUserName'));
     }),
 
     showInviteForm: computed('selectedUser', 'selectedUnregisteredUser', function() {
@@ -74,14 +78,14 @@ export default Component.extend(Validations, {
         resetInviteForm() {
             this.$('#toggle-form').click();
             this.setProperties({
-                fullName: '',
-                email: '',
+                unregisteredUserName: '',
+                unregisteredUserEmail: '',
             });
         },
         selectUnregistered() {
             if (this.get('isFormValid')) {
                 this.$('#toggle-form').click();
-                this.set('selectedUnregisteredUser', this.get('fullName'));
+                this.set('selectedUnregisteredUser', true);
             }
         },
     },

--- a/app/components/moderator-list-add/component.js
+++ b/app/components/moderator-list-add/component.js
@@ -3,20 +3,55 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 
 import { task, timeout } from 'ember-concurrency';
+import { validator, buildValidations } from 'ember-cp-validations';
 
 
 const DEBOUNCE_MS = 250;
 
-export default Component.extend({
+/* Validations for adding unregistered contributor form.  fullName must be present
+and have three letters, and the username (email) must be present and of appropriate format.
+*/
+const Validations = buildValidations({
+    fullName: {
+        description: 'Full name',
+        validators: [
+            validator('presence', true),
+            validator('length', {
+                min: 3,
+            }),
+        ],
+    },
+    email: {
+        description: 'Email',
+        validators: [
+            validator('presence', true),
+            validator('format', {
+                type: 'email',
+                regex: /^[-a-z0-9~!$%^&*_=+}{'?]+(\.[-a-z0-9~!$%^&*_=+}{'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i,
+            }),
+        ],
+    },
+});
+
+export default Component.extend(Validations, {
     i18n: service(),
     store: service(),
 
     selectedUser: '',
+    selectedUnregisteredUser: '',
     roleLabel: 'Role',
     role: '',
+    fullName: null,
+    email: null,
+
+    isFormValid: computed.alias('validations.isValid'),
 
     disableSave: computed('role', 'selectedUser', function() {
         return !this.get('role') || !this.get('selectedUser');
+    }),
+
+    showInviteForm: computed('selectedUser', 'selectedUnregisteredUser', function() {
+        return !this.get('selectedUser') && !this.get('selectedUnregisteredUser');
     }),
 
     actions: {
@@ -35,6 +70,19 @@ export default Component.extend({
                 role: '',
                 selectedUser: '',
             });
+        },
+        resetInviteForm() {
+            this.$('#toggle-form').click();
+            this.setProperties({
+                fullName: '',
+                email: '',
+            });
+        },
+        selectUnregistered() {
+            if (this.get('isFormValid')) {
+                this.$('#toggle-form').click();
+                this.set('selectedUnregisteredUser', this.get('fullName'));
+            }
         },
     },
 

--- a/app/components/moderator-list-add/style.scss
+++ b/app/components/moderator-list-add/style.scss
@@ -1,3 +1,7 @@
+.ember-power-select-selected-item {
+  margin-left: 0;
+}
+
 .moderators-add-row-container {
   display: inline-grid;
   grid-template-columns: 2fr 1fr 1fr;

--- a/app/components/moderator-list-add/style.scss
+++ b/app/components/moderator-list-add/style.scss
@@ -1,12 +1,3 @@
-.row-container {
-  display: inline-grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  align-items: center;
-  justify-items: start;
-  width: 100%;
-  min-height: 60px;
-}
-
 .moderator-name {
   width: 100%;
   display: inline-flex;

--- a/app/components/moderator-list-add/style.scss
+++ b/app/components/moderator-list-add/style.scss
@@ -2,6 +2,7 @@
   width: 100%;
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
 
   .ember-power-select-trigger {
     min-width: 200px;
@@ -38,7 +39,10 @@
 }
 
 .row-controls {
-  justify-self: end;
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  justify-self: flex-end;
 }
 
 .unregistered-dropdown {

--- a/app/components/moderator-list-add/style.scss
+++ b/app/components/moderator-list-add/style.scss
@@ -14,6 +14,15 @@
   border: none;
   background-color: transparent;
   padding: 2px 5px;
+
+  :hover {
+    background-color: none;
+    border-color: none;
+  }
+}
+
+.open > .dropdown-link {
+  box-shadow: 0 0 3px;
 }
 
 .role-dropdown {

--- a/app/components/moderator-list-add/style.scss
+++ b/app/components/moderator-list-add/style.scss
@@ -1,0 +1,42 @@
+.row-container {
+  display: inline-grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  align-items: center;
+  justify-items: start;
+  width: 100%;
+  min-height: 60px;
+}
+
+.moderator-name {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+
+  .ember-power-select-trigger {
+    min-width: 200px;
+    background-color: transparent;
+  }
+}
+
+.dropdown-link {
+  color: $brand-primary;
+  border: none;
+  background-color: transparent;
+  padding: 2px 5px;
+}
+
+.role-dropdown {
+  .dropdown-button {
+    min-width: 115px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .invite-dropdown {
+    background-color: $color-white;
+  }
+}
+
+.row-controls {
+  justify-self: end;
+}

--- a/app/components/moderator-list-add/style.scss
+++ b/app/components/moderator-list-add/style.scss
@@ -31,3 +31,12 @@
 .row-controls {
   justify-self: end;
 }
+
+.unregistered-dropdown {
+  background-color: $color-white;
+  width: 275px;
+}
+
+.unregistered-form {
+  padding: 10px;
+}

--- a/app/components/moderator-list-add/style.scss
+++ b/app/components/moderator-list-add/style.scss
@@ -1,3 +1,13 @@
+.moderators-add-row-container {
+  display: inline-grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  grid-template-rows: 1;
+  align-items: center;
+  justify-items: start;
+  width: 100%;
+  min-height: 60px;
+}
+
 .moderator-name {
   width: 100%;
   display: inline-flex;
@@ -10,11 +20,29 @@
   }
 }
 
+@media (max-width: 700px) {
+  .moderators-add-row-container {
+    display: inline-grid;
+    grid-template-columns: 2fr 2fr;
+    grid-template-rows: 1fr 1fr;
+    align-items: center;
+    justify-items: start;
+    width: 100%;
+    min-height: 60px;
+  }
+
+  .moderator-name {
+    grid-column-start: 1;
+    grid-column-end: 3;
+  }
+}
+
 .dropdown-link {
   color: $brand-primary;
   border: none;
   background-color: transparent;
-  padding: 2px 5px;
+  padding: 2px 2px;
+  margin: 0 3px;
 
   :hover {
     background-color: none;

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -1,4 +1,4 @@
-<div class="row-container p-h-md p-v-sm">
+<div class="moderators-row-container p-h-md p-v-sm">
     <div class="moderator-name">
         {{#if fetchData.isRunning}}
             {{#content-placeholders as |placeholder|}}
@@ -8,7 +8,6 @@
             {{#power-select
                 options=users
                 search=(perform searchUsers)
-                searchField='fullName'
                 placeholder='Search by name'
                 selected=selectedUser
                 onchange=(action (mut selectedUser)) as |user|}}
@@ -18,7 +17,7 @@
             <span class="p-l-xs">or</span>
             {{#bs-dropdown classNames="pull-right invite-dropdown" as |dd|}}
                 {{#dd.toggle classNames="btn btn-default dropdown-link"}}
-                    invite by email
+                    {{t 'components.moderatorListAdd.inviteText'}}
                 {{/dd.toggle}}
                 {{#dd.menu classNames="dropdown-menu-right" as |menu|}}
                     Placeholder
@@ -28,23 +27,25 @@
     </div>
     {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
         {{#dd.button classNames="btn btn-default dropdown-button"}}
-            {{role}}
+            {{roleLabel}}
             <span class="fa fa-caret-down p-l-xs"></span>
         {{/dd.button}}
         {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
             {{#each roleOptions as |roleOption|}}
                 {{#menu.item}}
-                    <button class="btn" {{action 'roleChanged' roleOption.label}}>
+                    <button class="btn" {{action 'roleChanged' roleOption.role}}>
                         {{roleOption.label}}
-                        <i class='{{if (eq role roleOption.label) 'fa fa-check selected' 'not-selected'}}'></i>
+                        <i class='{{if (eq role roleOption.role) 'fa fa-check selected' 'not-selected'}}'></i>
                     </button>
                 {{/menu.item}}
             {{/each}}
         {{/dd.menu}}
     {{/bs-dropdown}}
     <div class="row-controls">
-        <button class="btn btn-default" {{action 'cancel'}}>Cancel</button>
-        <button class="btn btn-success m-l-xs" disabled={{disableSave}} onclick={{perform saveModerator}}>Save</button>
+        <button class="btn btn-default" {{action 'cancel'}}>{{t 'global.cancel'}}</button>
+        <button class="btn btn-success m-l-xs" disabled={{disableSave}} onclick={{perform addModerator selectedUser.id role}}>
+            {{t 'global.save'}}
+        </button>
     </div>
 </div>
-<div class="row-border"></div>
+<div class="moderators-row-border"></div>

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -1,67 +1,61 @@
 <div class="moderators-row-container p-h-md p-v-sm">
     <div class="moderator-name">
-        {{#if fetchData.isRunning}}
-            {{#content-placeholders as |placeholder|}}
-                {{placeholder.text lines=1}}
-            {{/content-placeholders}}
+        {{#if (not selectedUnregisteredUser)}}
+            {{#power-select
+                disabled=loadingModerators
+                options=users
+                search=(perform searchUsers)
+                placeholder='Search by name'
+                selected=selectedUser
+                onchange=(action (mut selectedUser)) as |user|}}
+                <img class="m-xs" src="{{user.profileImage}}" height=25 width=25 alt="{{user.fullName}} gravatar">
+                <span>{{user.fullName}}</span>
+            {{/power-select}}
         {{else}}
-            {{#if (not selectedUnregisteredUser)}}
-                {{#power-select
-                    disabled=loadingModerators
-                    options=users
-                    search=(perform searchUsers)
-                    placeholder='Search by name'
-                    selected=selectedUser
-                    onchange=(action (mut selectedUser)) as |user|}}
-                    <img class="m-xs" src="{{user.profileImage}}" height=25 width=25 alt="{{user.fullName}} gravatar">
-                    <span>{{user.fullName}}</span>
-                {{/power-select}}
-            {{else}}
-                <i>{{unregisteredUserName}}</i>
-            {{/if}}
-            {{#if showInviteForm}}
-                <span class="p-l-xs">or</span>
-                {{#bs-dropdown classNames="pull-right invite-dropdown" closeOnMenuClick=false as |dd|}}
-                    {{#dd.toggle id="toggle-form" classNames="btn dropdown-link"}}
-                        {{t 'components.moderatorListAdd.inviteText'}}
-                    {{/dd.toggle}}
-                    {{#dd.menu classNames="dropdown-menu-right unregistered-dropdown" tagName="div" as |menu|}}
-                        {{#menu.item classNames="unregistered-form" tagName="form"}}
-                            <div>
-                                <label>{{t "components.unregisteredContributorForm.fullNameLabel"}}</label>
-                                <form>
-                                    {{validated-input
-                                        model=this
-                                        valuePath='fullName'
-                                        placeholder=(t "components.unregisteredContributorForm.fullNameLabel")
-                                        value=unregisteredUserName}}
-                                </form>
-                            </div>
-                            <div>
-                                <label>{{t "components.unregisteredContributorForm.emailLabel"}}</label>
-                                <form>
-                                    {{validated-input
-                                        model=this
-                                        valuePath='email'
-                                        placeholder=(t "components.unregisteredContributorForm.emailLabel")
-                                        value=unregisteredUserEmail}}
-                                </form>
-                            </div>
-                            <p class="text-muted">
-                                {{t "components.unregisteredContributorForm.notifyMessage"}}
-                            </p>
-                            <div class="pull-right p-t-xs p-b-sm">
-                                <button type="button" class="btn btn-default btn-small" {{action 'resetInviteForm'}}>
-                                    {{t "global.cancel"}}
-                                </button>
-                                <button type="submit" class="btn btn-success btn-small m-l-xs" {{action 'selectUnregistered'}} disabled={{not isFormValid}}>
-                                    {{t "global.add"}}
-                                </button>
-                            </div>
-                        {{/menu.item}}
-                    {{/dd.menu}}
-                {{/bs-dropdown}}
-            {{/if}}
+            <i>{{unregisteredUserName}}</i>
+        {{/if}}
+        {{#if showInviteForm}}
+            <span class="p-l-xs">or</span>
+            {{#bs-dropdown classNames="pull-right invite-dropdown" closeOnMenuClick=false as |dd|}}
+                {{#dd.toggle id="toggle-form" classNames="btn dropdown-link"}}
+                    {{t 'components.moderatorListAdd.inviteText'}}
+                {{/dd.toggle}}
+                {{#dd.menu classNames="dropdown-menu-right unregistered-dropdown" tagName="div" as |menu|}}
+                    {{#menu.item classNames="unregistered-form" tagName="form"}}
+                        <div>
+                            <label>{{t "components.unregisteredContributorForm.fullNameLabel"}}</label>
+                            <form>
+                                {{validated-input
+                                    model=this
+                                    valuePath='fullName'
+                                    placeholder=(t "components.unregisteredContributorForm.fullNameLabel")
+                                    value=unregisteredUserName}}
+                            </form>
+                        </div>
+                        <div>
+                            <label>{{t "components.unregisteredContributorForm.emailLabel"}}</label>
+                            <form>
+                                {{validated-input
+                                    model=this
+                                    valuePath='email'
+                                    placeholder=(t "components.unregisteredContributorForm.emailLabel")
+                                    value=unregisteredUserEmail}}
+                            </form>
+                        </div>
+                        <p class="text-muted">
+                            {{t "components.unregisteredContributorForm.notifyMessage"}}
+                        </p>
+                        <div class="pull-right p-t-xs p-b-sm">
+                            <button type="button" class="btn btn-default btn-small" {{action 'resetInviteForm'}}>
+                                {{t "global.cancel"}}
+                            </button>
+                            <button type="submit" class="btn btn-success btn-small m-l-xs" {{action 'selectUnregistered'}} disabled={{not isFormValid}}>
+                                {{t "global.add"}}
+                            </button>
+                        </div>
+                    {{/menu.item}}
+                {{/dd.menu}}
+            {{/bs-dropdown}}
         {{/if}}
     </div>
     {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -16,12 +16,12 @@
                     <span>{{user.fullName}}</span>
                 {{/power-select}}
             {{else}}
-                <i>{{selectedUnregisteredUser}}</i>
+                <i>{{unregisteredUserName}}</i>
             {{/if}}
             {{#if showInviteForm}}
                 <span class="p-l-xs">or</span>
                 {{#bs-dropdown classNames="pull-right invite-dropdown" closeOnMenuClick=false as |dd|}}
-                    {{#dd.toggle id="toggle-form" classNames="btn btn-default dropdown-link"}}
+                    {{#dd.toggle id="toggle-form" classNames="btn dropdown-link"}}
                         {{t 'components.moderatorListAdd.inviteText'}}
                     {{/dd.toggle}}
                     {{#dd.menu classNames="dropdown-menu-right unregistered-dropdown" tagName="div" as |menu|}}
@@ -33,7 +33,7 @@
                                         model=this
                                         valuePath='fullName'
                                         placeholder=(t "components.unregisteredContributorForm.fullNameLabel")
-                                        value=fullName}}
+                                        value=unregisteredUserName}}
                                 </form>
                             </div>
                             <div>
@@ -43,7 +43,7 @@
                                         model=this
                                         valuePath='email'
                                         placeholder=(t "components.unregisteredContributorForm.emailLabel")
-                                        value=email}}
+                                        value=unregisteredUserEmail}}
                                 </form>
                             </div>
                             <p class="text-muted">
@@ -83,7 +83,7 @@
         <button class="btn btn-default" {{action 'cancel'}} disabled={{addModerator.isRunning}}>
             {{t 'global.cancel'}}
         </button>
-        <button class="btn btn-success m-l-xs" disabled={{disableSave}} onclick={{perform addModerator selectedUser.id role}}>
+        <button class="btn btn-success m-l-xs" disabled={{disableSave}} onclick={{perform addModerator selectedUserId role unregisteredUserName}}>
             {{#if addModerator.isRunning}}
                 {{loading-btn-indicator}}
             {{else}}

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -5,24 +5,62 @@
                 {{placeholder.text lines=1}}
             {{/content-placeholders}}
         {{else}}
-            {{#power-select
-                options=users
-                search=(perform searchUsers)
-                placeholder='Search by name'
-                selected=selectedUser
-                onchange=(action (mut selectedUser)) as |user|}}
+            {{#if (not selectedUnregisteredUser)}}
+                {{#power-select
+                    options=users
+                    search=(perform searchUsers)
+                    placeholder='Search by name'
+                    selected=selectedUser
+                    onchange=(action (mut selectedUser)) as |user|}}
                     <img class="m-xs" src="{{user.links.profile_image}}" height=25 width=25 alt="{{user.fullName}} gravatar">
                     <span>{{user.fullName}}</span>
-            {{/power-select}}
-            <span class="p-l-xs">or</span>
-            {{#bs-dropdown classNames="pull-right invite-dropdown" as |dd|}}
-                {{#dd.toggle classNames="btn btn-default dropdown-link"}}
-                    {{t 'components.moderatorListAdd.inviteText'}}
-                {{/dd.toggle}}
-                {{#dd.menu classNames="dropdown-menu-right" as |menu|}}
-                    Placeholder
-                {{/dd.menu}}
-            {{/bs-dropdown}}
+                {{/power-select}}
+            {{else}}
+                <i>{{selectedUnregisteredUser}}</i>
+            {{/if}}
+            {{#if showInviteForm}}
+                <span class="p-l-xs">or</span>
+                {{#bs-dropdown classNames="pull-right invite-dropdown" closeOnMenuClick=false as |dd|}}
+                    {{#dd.toggle id="toggle-form" classNames="btn btn-default dropdown-link"}}
+                        {{t 'components.moderatorListAdd.inviteText'}}
+                    {{/dd.toggle}}
+                    {{#dd.menu classNames="dropdown-menu-right unregistered-dropdown" tagName="div" as |menu|}}
+                        {{#menu.item classNames="unregistered-form" tagName="form"}}
+                            <div>
+                                <label>{{t "components.unregisteredContributorForm.fullNameLabel"}}</label>
+                                <form>
+                                    {{validated-input
+                                        model=this
+                                        valuePath='fullName'
+                                        placeholder=(t "components.unregisteredContributorForm.fullNameLabel")
+                                        value=fullName}}
+                                </form>
+                            </div>
+                            <div>
+                                <label>{{t "components.unregisteredContributorForm.emailLabel"}}</label>
+                                <form>
+                                    {{validated-input
+                                        model=this
+                                        valuePath='email'
+                                        placeholder=(t "components.unregisteredContributorForm.emailLabel")
+                                        value=email}}
+                                </form>
+                            </div>
+                            <p class="text-muted">
+                                {{t "components.unregisteredContributorForm.notifyMessage"}}
+                            </p>
+                            <div class="pull-right p-t-xs p-b-sm">
+                                <button type="button" class="btn btn-default btn-small" {{action 'resetInviteForm'}}>
+                                    {{t "global.cancel"}}
+                                </button>
+                                <button type="submit" class="btn btn-success btn-small m-l-xs" {{action 'selectUnregistered'}} disabled={{not isFormValid}}>
+                                    {{t "global.add"}}
+                                </button>
+                            </div>
+                        {{/menu.item}}
+                    {{/dd.menu}}
+                {{/bs-dropdown}}
+            {{/if}}
         {{/if}}
     </div>
     {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -7,12 +7,13 @@
         {{else}}
             {{#if (not selectedUnregisteredUser)}}
                 {{#power-select
+                    disabled=loadingModerators
                     options=users
                     search=(perform searchUsers)
                     placeholder='Search by name'
                     selected=selectedUser
                     onchange=(action (mut selectedUser)) as |user|}}
-                    <img class="m-xs" src="{{user.links.profile_image}}" height=25 width=25 alt="{{user.fullName}} gravatar">
+                    <img class="m-xs" src="{{user.profileImage}}" height=25 width=25 alt="{{user.fullName}} gravatar">
                     <span>{{user.fullName}}</span>
                 {{/power-select}}
             {{else}}

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -1,4 +1,4 @@
-<div class="moderators-row-container p-h-md p-v-sm">
+<div class="moderators-add-row-container p-h-md p-v-sm">
     <div class="moderator-name">
         {{#if (not selectedUnregisteredUser)}}
             {{#power-select
@@ -8,19 +8,21 @@
                 placeholder='Search by name'
                 selected=selectedUser
                 onchange=(action (mut selectedUser)) as |user|}}
-                <img class="m-xs" src="{{user.profileImage}}" height=25 width=25 alt="{{user.fullName}} gravatar">
-                <span>{{user.fullName}}</span>
+                <div style="display: flex; align-items: center;">
+                    <img class="m-xs" src="{{user.profileImage}}" height=25 width=25 alt="{{user.fullName}} gravatar">
+                    <div>{{user.fullName}}</div>
+                </div>
             {{/power-select}}
         {{else}}
             <i>{{unregisteredUserName}}</i>
         {{/if}}
         {{#if showInviteForm}}
             <span class="p-l-xs">or</span>
-            {{#bs-dropdown classNames="pull-right invite-dropdown" closeOnMenuClick=false as |dd|}}
+            {{#bs-dropdown classNames="invite-dropdown" closeOnMenuClick=false as |dd|}}
                 {{#dd.toggle id="toggle-form" classNames="btn dropdown-link"}}
                     {{t 'components.moderatorListAdd.inviteText'}}
                 {{/dd.toggle}}
-                {{#dd.menu classNames="dropdown-menu-right unregistered-dropdown" tagName="div" as |menu|}}
+                {{#dd.menu classNames="unregistered-dropdown" tagName="div" as |menu|}}
                     {{#menu.item classNames="unregistered-form" tagName="form"}}
                         <div>
                             <label>{{t "components.unregisteredContributorForm.fullNameLabel"}}</label>
@@ -58,12 +60,12 @@
             {{/bs-dropdown}}
         {{/if}}
     </div>
-    {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
+    {{#bs-dropdown classNames="role-dropdown" as |dd|}}
         {{#dd.button classNames="btn btn-default dropdown-button"}}
             {{roleLabel}}
             <span class="fa fa-caret-down p-l-xs"></span>
         {{/dd.button}}
-        {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
+        {{#dd.menu classNames="moderator-dropdown-menu" as |menu|}}
             {{#each roleOptions as |roleOption|}}
                 {{#menu.item}}
                     <button class="btn" {{action 'roleChanged' roleOption.role}}>

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -80,9 +80,15 @@
         {{/dd.menu}}
     {{/bs-dropdown}}
     <div class="row-controls">
-        <button class="btn btn-default" {{action 'cancel'}}>{{t 'global.cancel'}}</button>
+        <button class="btn btn-default" {{action 'cancel'}} disabled={{addModerator.isRunning}}>
+            {{t 'global.cancel'}}
+        </button>
         <button class="btn btn-success m-l-xs" disabled={{disableSave}} onclick={{perform addModerator selectedUser.id role}}>
-            {{t 'global.save'}}
+            {{#if addModerator.isRunning}}
+                {{loading-btn-indicator}}
+            {{else}}
+                {{t 'global.save'}}
+            {{/if}}
         </button>
     </div>
 </div>

--- a/app/components/moderator-list-add/template.hbs
+++ b/app/components/moderator-list-add/template.hbs
@@ -1,0 +1,50 @@
+<div class="row-container p-h-md p-v-sm">
+    <div class="moderator-name">
+        {{#if fetchData.isRunning}}
+            {{#content-placeholders as |placeholder|}}
+                {{placeholder.text lines=1}}
+            {{/content-placeholders}}
+        {{else}}
+            {{#power-select
+                options=users
+                search=(perform searchUsers)
+                searchField='fullName'
+                placeholder='Search by name'
+                selected=selectedUser
+                onchange=(action (mut selectedUser)) as |user|}}
+                    <img class="m-xs" src="{{user.links.profile_image}}" height=25 width=25 alt="{{user.fullName}} gravatar">
+                    <span>{{user.fullName}}</span>
+            {{/power-select}}
+            <span class="p-l-xs">or</span>
+            {{#bs-dropdown classNames="pull-right invite-dropdown" as |dd|}}
+                {{#dd.toggle classNames="btn btn-default dropdown-link"}}
+                    invite by email
+                {{/dd.toggle}}
+                {{#dd.menu classNames="dropdown-menu-right" as |menu|}}
+                    Placeholder
+                {{/dd.menu}}
+            {{/bs-dropdown}}
+        {{/if}}
+    </div>
+    {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
+        {{#dd.button classNames="btn btn-default dropdown-button"}}
+            {{role}}
+            <span class="fa fa-caret-down p-l-xs"></span>
+        {{/dd.button}}
+        {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
+            {{#each roleOptions as |roleOption|}}
+                {{#menu.item}}
+                    <button class="btn" {{action 'roleChanged' roleOption.label}}>
+                        {{roleOption.label}}
+                        <i class='{{if (eq role roleOption.label) 'fa fa-check selected' 'not-selected'}}'></i>
+                    </button>
+                {{/menu.item}}
+            {{/each}}
+        {{/dd.menu}}
+    {{/bs-dropdown}}
+    <div class="row-controls">
+        <button class="btn btn-default" {{action 'cancel'}}>Cancel</button>
+        <button class="btn btn-success m-l-xs" disabled={{disableSave}} onclick={{perform saveModerator}}>Save</button>
+    </div>
+</div>
+<div class="row-border"></div>

--- a/app/components/moderator-list-row/component.js
+++ b/app/components/moderator-list-row/component.js
@@ -66,13 +66,6 @@ export default Component.extend({
         }
     },
 
-    removeModerator: task(function* (moderatorId) {
-        const removed = yield this.get('deleteModerator').perform(moderatorId);
-        if (removed) {
-            this.set('removeConfirmation', false);
-        }
-    }),
-
     editModerator: task(function* (moderatorId, permissionGroup) {
         const saved = yield this.get('updateModerator').perform(moderatorId, permissionGroup);
         if (saved) {

--- a/app/components/moderator-list-row/component.js
+++ b/app/components/moderator-list-row/component.js
@@ -25,6 +25,10 @@ export default Component.extend({
         return (this.get('role') === 'admin' && this.get('disableAdminDeletion')) || this.get('editingModerator');
     }),
 
+    disableRoleSelect: computed('disableRemove', 'editConfirmation', function() {
+        return this.get('disableRemove') && !this.get('editConfirmation');
+    }),
+
     didReceiveAttrs() {
         this.get('fetchData').perform();
     },

--- a/app/components/moderator-list-row/component.js
+++ b/app/components/moderator-list-row/component.js
@@ -37,7 +37,7 @@ export default Component.extend({
             });
             this._setRole(role);
         },
-        removeModerator() {
+        removeInitiated() {
             this.setProperties({
                 editingModerator: true,
                 removeConfirmation: true,
@@ -61,6 +61,13 @@ export default Component.extend({
             }
         }
     },
+
+    removeModerator: task(function* (moderatorId) {
+        const removed = yield this.get('deleteModerator').perform(moderatorId);
+        if (removed) {
+            this.set('removeConfirmation', false);
+        }
+    }),
 
     editModerator: task(function* (moderatorId, permissionGroup) {
         const saved = yield this.get('updateModerator').perform(moderatorId, permissionGroup);

--- a/app/components/moderator-list-row/component.js
+++ b/app/components/moderator-list-row/component.js
@@ -1,0 +1,54 @@
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+
+import { task } from 'ember-concurrency';
+
+
+export default Component.extend({
+    i18n: service(),
+    store: service(),
+
+    showConfirmation: false,
+
+    role: computed('moderator.permissionGroup', 'roleOptions', function() {
+        for (const value of this.get('roleOptions')) {
+            if (value.role === this.get('moderator.permissionGroup')) {
+                return value.label;
+            }
+        }
+        return 'Role';
+    }),
+
+    disableRemove: computed('role', 'disableAdminDeletion', 'editingModerator', function() {
+        return (this.get('role') === 'Admin' && this.get('disableAdminDeletion')) || this.get('editingModerator');
+    }),
+
+    didReceiveAttrs() {
+        this.get('fetchData').perform();
+    },
+
+    actions: {
+        roleChanged(role) {
+            this.set('role', role);
+        },
+        removeModerator() {
+            this.setProperties({
+                editingModerator: true,
+                showConfirmation: true,
+            });
+        },
+        cancel() {
+            this.setProperties({
+                editingModerator: false,
+                showConfirmation: false,
+            });
+        },
+    },
+
+    fetchData: task(function* () {
+        const moderatorId = this.get('moderator.id');
+        const response = yield this.get('store').findRecord('user', moderatorId);
+        this.set('user', response);
+    }),
+});

--- a/app/components/moderator-list-row/component.js
+++ b/app/components/moderator-list-row/component.js
@@ -22,7 +22,7 @@ export default Component.extend({
     }),
 
     disableRemove: computed('role', 'disableAdminDeletion', 'editingModerator', function() {
-        return (this.get('role') === 'Admin' && this.get('disableAdminDeletion')) || this.get('editingModerator');
+        return (this.get('role') === 'admin' && this.get('disableAdminDeletion')) || this.get('editingModerator');
     }),
 
     didReceiveAttrs() {

--- a/app/components/moderator-list-row/style.scss
+++ b/app/components/moderator-list-row/style.scss
@@ -18,4 +18,6 @@
 
 .moderator-name {
   width: 100%;
+  display: flex;
+  align-items: center;
 }

--- a/app/components/moderator-list-row/style.scss
+++ b/app/components/moderator-list-row/style.scss
@@ -1,5 +1,37 @@
-.role-dropdown {
+.moderators-list-row-container {
+  display: inline-grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  grid-template-rows: 1;
+  align-items: center;
+  justify-items: start;
+  width: 100%;
+  min-height: 60px;
+}
 
+.moderator-name {
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+
+@media (max-width: 700px) {
+  .moderators-list-row-container {
+    display: inline-grid;
+    grid-template-columns: 2fr 2fr;
+    grid-template-rows: 1fr 1fr;
+    align-items: center;
+    justify-items: start;
+    width: 100%;
+    min-height: 60px;
+  }
+
+  .moderator-name {
+    grid-column-start: 1;
+    grid-column-end: 3;
+  }
+}
+
+.role-dropdown {
   .dropdown-button {
     min-width: 115px;
     display: flex;
@@ -14,10 +46,4 @@
   .remove-button {
     color: $color-text-gray-dark;
   }
-}
-
-.moderator-name {
-  width: 100%;
-  display: flex;
-  align-items: center;
 }

--- a/app/components/moderator-list-row/style.scss
+++ b/app/components/moderator-list-row/style.scss
@@ -1,11 +1,3 @@
-.row-container {
-  display: inline-grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  align-items: center;
-  justify-items: start;
-  width: 100%;
-}
-
 .role-dropdown {
 
   .dropdown-button {
@@ -22,4 +14,8 @@
   .remove-button {
     color: #343333;
   }
+}
+
+.moderator-name {
+  width: 100%;
 }

--- a/app/components/moderator-list-row/style.scss
+++ b/app/components/moderator-list-row/style.scss
@@ -9,10 +9,10 @@
 }
 
 .row-controls {
-  justify-self: end;
+  justify-self: flex-end;
 
   .remove-button {
-    color: #343333;
+    color: $color-text-gray-dark;
   }
 }
 

--- a/app/components/moderator-list-row/style.scss
+++ b/app/components/moderator-list-row/style.scss
@@ -1,0 +1,25 @@
+.row-container {
+  display: inline-grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  align-items: center;
+  justify-items: start;
+  width: 100%;
+}
+
+.role-dropdown {
+
+  .dropdown-button {
+    min-width: 115px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.row-controls {
+  justify-self: end;
+
+  .remove-button {
+    color: #343333;
+  }
+}

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -37,8 +37,8 @@
                 <button class="btn btn-default" {{action 'cancel'}} disabled={{removeModerator.isRunning}}>
                     {{t 'global.cancel'}}
                 </button>
-                <button class="btn btn-danger m-l-xs" onclick={{perform removeModerator moderator.id}} disabled={{removeModerator.isRunning}}>
-                    {{#if removeModerator.isRunning}}
+                <button class="btn btn-danger m-l-xs" onclick={{perform deleteModerator moderator.id}} disabled={{deleteModerator.isRunning}}>
+                    {{#if deleteModerator.isRunning}}
                         {{loading-btn-indicator}}
                     {{else}}
                         {{t 'global.remove'}}

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -32,14 +32,26 @@
     {{/bs-dropdown}}
     <div class="row-controls">
         {{#if removeConfirmation}}
-            <button class="btn btn-default" {{action 'cancel'}}>{{t 'global.cancel'}}</button>
-            <button class="btn btn-danger m-l-xs" onclick={{perform deleteModerator moderator.id}}>
-                {{t 'global.remove'}}
+            <button class="btn btn-default" {{action 'cancel'}} disabled={{removeModerator.isRunning}}>
+                {{t 'global.cancel'}}
+            </button>
+            <button class="btn btn-danger m-l-xs" onclick={{perform removeModerator moderator.id}} disabled={{removeModerator.isRunning}}>
+                {{#if removeModerator.isRunning}}
+                    {{loading-btn-indicator}}
+                {{else}}
+                    {{t 'global.remove'}}
+                {{/if}}
             </button>
         {{else if editConfirmation}}
-            <button class="btn btn-default" {{action 'cancel'}}>{{t 'global.cancel'}}</button>
-            <button class="btn btn-success m-l-xs" onclick={{perform editModerator moderator.id role}}>
-                {{t 'global.save'}}
+            <button class="btn btn-default" {{action 'cancel'}} disabled={{editModerator.isRunning}}>
+                {{t 'global.cancel'}}
+            </button>
+            <button class="btn btn-success m-l-xs" onclick={{perform editModerator moderator.id role}} disabled={{editModerator.isRunning}}>
+                {{#if editModerator.isRunning}}
+                    {{loading-btn-indicator}}
+                {{else}}
+                    {{t 'global.save'}}
+                {{/if}}
             </button>
         {{else}}
             {{#if (and editingModerator disableRemove)}}
@@ -51,7 +63,7 @@
                     {{t 'components.moderatorList.adminDisabledMessage'}}
                 {{/bs-tooltip}}
             {{/if}}
-            <a role="button" class="remove-button {{if disableRemove 'disabled'}}" {{action 'removeModerator'}}>
+            <a role="button" class="remove-button {{if disableRemove 'disabled'}}" {{action 'removeInitiated'}}>
                 <i class="fa fa-times fa-lg "></i>
             </a>
         {{/if}}

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -1,0 +1,47 @@
+<div class="row-container p-h-md p-v-sm">
+    <div class="moderator-name">
+        {{#if fetchData.isRunning}}
+            {{#content-placeholders as |placeholder|}}
+                {{placeholder.img height=30}}
+            {{/content-placeholders}}
+            <span class="name">{{moderator.fullname}}</span>
+        {{else}}
+            <img src={{user.links.profile_image}} height=40 width=40>
+            <span class="name p-l-sm">
+                <a href="{{user.links.html}}">{{moderator.fullName}}</a>
+            </span>
+        {{/if}}
+    </div>
+    {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
+        {{#dd.button classNames="btn btn-default dropdown-button" disabled=(and disableAdminDeletion (eq role 'Admin'))}}
+            {{role}}
+            <span class="fa fa-caret-down p-l-xs"></span>
+        {{/dd.button}}
+        {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
+            {{#each roleOptions as |roleOption|}}
+                {{#menu.item}}
+                    <button class="btn" {{action 'roleChanged' roleOption.label}}>
+                        {{roleOption.label}}
+                        <i class='{{if (eq role roleOption.label) 'fa fa-check selected' 'not-selected'}}'></i>
+                    </button>
+                {{/menu.item}}
+            {{/each}}
+        {{/dd.menu}}
+    {{/bs-dropdown}}
+    <div class="row-controls">
+        {{#if showConfirmation}}
+            <button class="btn btn-default" {{action 'cancel'}}>Cancel</button>
+            <button class="btn btn-danger m-l-xs">Remove</button>
+        {{else}}
+            {{#if (and editingModerator disableRemove)}}
+                {{#bs-tooltip placement='left'}}Can only edit one moderator at a time{{/bs-tooltip}}
+            {{else if (and disableAdminDeletion disableRemove)}}
+                {{#bs-tooltip placement='left'}}Must have one admin{{/bs-tooltip}}
+            {{/if}}
+            <a role="button" class="remove-button {{if disableRemove 'disabled'}}" {{action 'removeModerator'}}>
+                <i class="fa fa-times fa-lg "></i>
+            </a>
+        {{/if}}
+    </div>
+</div>
+<div class="row-border"></div>

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -1,4 +1,4 @@
-<div class="moderators-row-container p-h-md p-v-sm">
+<div class="moderators-list-row-container p-h-md p-v-sm">
     <div class="moderator-name">
         {{#if fetchData.isRunning}}
             <div class="name--skeleton">
@@ -16,12 +16,12 @@
         {{/if}}
     </div>
     {{#if isAdmin}}
-        {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
+        {{#bs-dropdown classNames="role-dropdown" as |dd|}}
             {{#dd.button classNames="btn btn-default dropdown-button" disabled=disableRoleSelect}}
                 {{roleLabel}}
                 <span class="fa fa-caret-down p-l-xs"></span>
             {{/dd.button}}
-            {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
+            {{#dd.menu classNames="moderator-dropdown-menu" as |menu|}}
                 {{#each roleOptions as |roleOption|}}
                     {{#menu.item}}
                         <button class="btn" {{action 'roleChanged' roleOption.role}}>

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -37,7 +37,7 @@
                 <button class="btn btn-default" {{action 'cancel'}} disabled={{removeModerator.isRunning}}>
                     {{t 'global.cancel'}}
                 </button>
-                <button class="btn btn-danger m-l-xs" onclick={{perform deleteModerator moderator.id}} disabled={{deleteModerator.isRunning}}>
+                <button class="btn btn-danger m-l-xs" onclick={{perform deleteModerator moderator}} disabled={{deleteModerator.isRunning}}>
                     {{#if deleteModerator.isRunning}}
                         {{loading-btn-indicator}}
                     {{else}}
@@ -48,7 +48,7 @@
                 <button class="btn btn-default" {{action 'cancel'}} disabled={{editModerator.isRunning}}>
                     {{t 'global.cancel'}}
                 </button>
-                <button class="btn btn-success m-l-xs" onclick={{perform editModerator moderator.id role}} disabled={{editModerator.isRunning}}>
+                <button class="btn btn-success m-l-xs" onclick={{perform editModerator moderator role}} disabled={{editModerator.isRunning}}>
                     {{#if editModerator.isRunning}}
                         {{loading-btn-indicator}}
                     {{else}}

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -1,10 +1,12 @@
-<div class="row-container p-h-md p-v-sm">
+<div class="moderators-row-container p-h-md p-v-sm">
     <div class="moderator-name">
         {{#if fetchData.isRunning}}
-            {{#content-placeholders as |placeholder|}}
-                {{placeholder.img height=30}}
-            {{/content-placeholders}}
-            <span class="name">{{moderator.fullname}}</span>
+            <div class="name--skeleton">
+                {{#content-placeholders as |placeholder|}}
+                    <div class="gravatar--skeleton">{{placeholder.img}}</div>
+                    <div class="m-l-sm">{{placeholder.text lines=1}}</div>
+                {{/content-placeholders}}
+            </div>
         {{else}}
             <img src={{user.links.profile_image}} height=40 width=40>
             <span class="name p-l-sm">
@@ -13,30 +15,41 @@
         {{/if}}
     </div>
     {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
-        {{#dd.button classNames="btn btn-default dropdown-button" disabled=(and disableAdminDeletion (eq role 'Admin'))}}
-            {{role}}
+        {{#dd.button classNames="btn btn-default dropdown-button" disabled=(and disableAdminDeletion (eq role 'admin'))}}
+            {{roleLabel}}
             <span class="fa fa-caret-down p-l-xs"></span>
         {{/dd.button}}
         {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
             {{#each roleOptions as |roleOption|}}
                 {{#menu.item}}
-                    <button class="btn" {{action 'roleChanged' roleOption.label}}>
+                    <button class="btn" {{action 'roleChanged' roleOption.role}}>
                         {{roleOption.label}}
-                        <i class='{{if (eq role roleOption.label) 'fa fa-check selected' 'not-selected'}}'></i>
+                        <i class='{{if (eq role roleOption.role) 'fa fa-check selected' 'not-selected'}}'></i>
                     </button>
                 {{/menu.item}}
             {{/each}}
         {{/dd.menu}}
     {{/bs-dropdown}}
     <div class="row-controls">
-        {{#if showConfirmation}}
-            <button class="btn btn-default" {{action 'cancel'}}>Cancel</button>
-            <button class="btn btn-danger m-l-xs">Remove</button>
+        {{#if removeConfirmation}}
+            <button class="btn btn-default" {{action 'cancel'}}>{{t 'global.cancel'}}</button>
+            <button class="btn btn-danger m-l-xs" onclick={{perform deleteModerator moderator.id}}>
+                {{t 'global.remove'}}
+            </button>
+        {{else if editConfirmation}}
+            <button class="btn btn-default" {{action 'cancel'}}>{{t 'global.cancel'}}</button>
+            <button class="btn btn-success m-l-xs" onclick={{perform editModerator moderator.id role}}>
+                {{t 'global.save'}}
+            </button>
         {{else}}
             {{#if (and editingModerator disableRemove)}}
-                {{#bs-tooltip placement='left'}}Can only edit one moderator at a time{{/bs-tooltip}}
+                {{#bs-tooltip placement='left'}}
+                    {{t 'components.moderatorList.editDisabledMessage'}}
+                {{/bs-tooltip}}
             {{else if (and disableAdminDeletion disableRemove)}}
-                {{#bs-tooltip placement='left'}}Must have one admin{{/bs-tooltip}}
+                {{#bs-tooltip placement='left'}}
+                    {{t 'components.moderatorList.adminDisabledMessage'}}
+                {{/bs-tooltip}}
             {{/if}}
             <a role="button" class="remove-button {{if disableRemove 'disabled'}}" {{action 'removeModerator'}}>
                 <i class="fa fa-times fa-lg "></i>
@@ -44,4 +57,4 @@
         {{/if}}
     </div>
 </div>
-<div class="row-border"></div>
+<div class="moderators-row-border"></div>

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -8,7 +8,7 @@
                 {{/content-placeholders}}
             </div>
         {{else}}
-            <img src={{user.links.profile_image}} height=40 width=40>
+            <img src={{user.links.profile_image}} height=40 width=40 alt="gravatar {{moderator.fullName}}">
             <span class="name p-l-sm">
                 <a href="{{user.links.html}}">{{moderator.fullName}}</a>
             </span>

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -15,7 +15,7 @@
         {{/if}}
     </div>
     {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
-        {{#dd.button classNames="btn btn-default dropdown-button" disabled=(and disableAdminDeletion (eq role 'admin'))}}
+        {{#dd.button classNames="btn btn-default dropdown-button" disabled=disableRoleSelect}}
             {{roleLabel}}
             <span class="fa fa-caret-down p-l-xs"></span>
         {{/dd.button}}

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -14,59 +14,61 @@
             </span>
         {{/if}}
     </div>
-    {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
-        {{#dd.button classNames="btn btn-default dropdown-button" disabled=disableRoleSelect}}
-            {{roleLabel}}
-            <span class="fa fa-caret-down p-l-xs"></span>
-        {{/dd.button}}
-        {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
-            {{#each roleOptions as |roleOption|}}
-                {{#menu.item}}
-                    <button class="btn" {{action 'roleChanged' roleOption.role}}>
-                        {{roleOption.label}}
-                        <i class='{{if (eq role roleOption.role) 'fa fa-check selected' 'not-selected'}}'></i>
-                    </button>
-                {{/menu.item}}
-            {{/each}}
-        {{/dd.menu}}
-    {{/bs-dropdown}}
-    <div class="row-controls">
-        {{#if removeConfirmation}}
-            <button class="btn btn-default" {{action 'cancel'}} disabled={{removeModerator.isRunning}}>
-                {{t 'global.cancel'}}
-            </button>
-            <button class="btn btn-danger m-l-xs" onclick={{perform removeModerator moderator.id}} disabled={{removeModerator.isRunning}}>
-                {{#if removeModerator.isRunning}}
-                    {{loading-btn-indicator}}
-                {{else}}
-                    {{t 'global.remove'}}
+    {{#if isAdmin}}
+        {{#bs-dropdown classNames="pull-right role-dropdown" as |dd|}}
+            {{#dd.button classNames="btn btn-default dropdown-button" disabled=disableRoleSelect}}
+                {{roleLabel}}
+                <span class="fa fa-caret-down p-l-xs"></span>
+            {{/dd.button}}
+            {{#dd.menu classNames="dropdown-menu-right moderator-dropdown-menu" as |menu|}}
+                {{#each roleOptions as |roleOption|}}
+                    {{#menu.item}}
+                        <button class="btn" {{action 'roleChanged' roleOption.role}}>
+                            {{roleOption.label}}
+                            <i class='{{if (eq role roleOption.role) 'fa fa-check selected' 'not-selected'}}'></i>
+                        </button>
+                    {{/menu.item}}
+                {{/each}}
+            {{/dd.menu}}
+        {{/bs-dropdown}}
+        <div class="row-controls">
+            {{#if removeConfirmation}}
+                <button class="btn btn-default" {{action 'cancel'}} disabled={{removeModerator.isRunning}}>
+                    {{t 'global.cancel'}}
+                </button>
+                <button class="btn btn-danger m-l-xs" onclick={{perform removeModerator moderator.id}} disabled={{removeModerator.isRunning}}>
+                    {{#if removeModerator.isRunning}}
+                        {{loading-btn-indicator}}
+                    {{else}}
+                        {{t 'global.remove'}}
+                    {{/if}}
+                </button>
+            {{else if editConfirmation}}
+                <button class="btn btn-default" {{action 'cancel'}} disabled={{editModerator.isRunning}}>
+                    {{t 'global.cancel'}}
+                </button>
+                <button class="btn btn-success m-l-xs" onclick={{perform editModerator moderator.id role}} disabled={{editModerator.isRunning}}>
+                    {{#if editModerator.isRunning}}
+                        {{loading-btn-indicator}}
+                    {{else}}
+                        {{t 'global.save'}}
+                    {{/if}}
+                </button>
+            {{else}}
+                {{#if (and editingModerator disableRemove)}}
+                    {{#bs-tooltip placement='left'}}
+                        {{t 'components.moderatorList.editDisabledMessage'}}
+                    {{/bs-tooltip}}
+                {{else if (and disableAdminDeletion disableRemove)}}
+                    {{#bs-tooltip placement='left'}}
+                        {{t 'components.moderatorList.adminDisabledMessage'}}
+                    {{/bs-tooltip}}
                 {{/if}}
-            </button>
-        {{else if editConfirmation}}
-            <button class="btn btn-default" {{action 'cancel'}} disabled={{editModerator.isRunning}}>
-                {{t 'global.cancel'}}
-            </button>
-            <button class="btn btn-success m-l-xs" onclick={{perform editModerator moderator.id role}} disabled={{editModerator.isRunning}}>
-                {{#if editModerator.isRunning}}
-                    {{loading-btn-indicator}}
-                {{else}}
-                    {{t 'global.save'}}
-                {{/if}}
-            </button>
-        {{else}}
-            {{#if (and editingModerator disableRemove)}}
-                {{#bs-tooltip placement='left'}}
-                    {{t 'components.moderatorList.editDisabledMessage'}}
-                {{/bs-tooltip}}
-            {{else if (and disableAdminDeletion disableRemove)}}
-                {{#bs-tooltip placement='left'}}
-                    {{t 'components.moderatorList.adminDisabledMessage'}}
-                {{/bs-tooltip}}
+                <a role="button" class="remove-button {{if disableRemove 'disabled'}}" {{action 'removeInitiated'}}>
+                    <i class="fa fa-times fa-lg "></i>
+                </a>
             {{/if}}
-            <a role="button" class="remove-button {{if disableRemove 'disabled'}}" {{action 'removeInitiated'}}>
-                <i class="fa fa-times fa-lg "></i>
-            </a>
-        {{/if}}
-    </div>
+        </div>
+    {{/if}}
 </div>
 <div class="moderators-row-border"></div>

--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -8,10 +8,11 @@
                 {{/content-placeholders}}
             </div>
         {{else}}
-            <img src={{user.links.profile_image}} height=40 width=40 alt="gravatar {{moderator.fullName}}">
-            <span class="name p-l-sm">
+            <img class="hidden-xs" src={{user.links.profile_image}} height=40 width=40 alt="gravatar {{moderator.fullName}}">
+            <img class="visible-xs" src="{{user.links.profile_image}}" height=25 width=25 alt="{{moderator.fullName}} gravatar">
+            <div class="name p-l-sm">
                 <a href="{{user.links.html}}">{{moderator.fullName}}</a>
-            </span>
+            </div>
         {{/if}}
     </div>
     {{#if isAdmin}}

--- a/app/components/provider-links/template.hbs
+++ b/app/components/provider-links/template.hbs
@@ -5,7 +5,7 @@
             {{placeholder.heading subtitle=false}}
         </span>
         <div class="provider-links">
-            <div class="provider-links--skeleton">{{placeholder.text lines=2}}</div>
+            <div class="provider-links--skeleton">{{placeholder.text lines=3}}</div>
         </div>
     {{/content-placeholders}}
 {{else}}
@@ -21,6 +21,11 @@
                 {{/link-to}}
                 {{#link-to 'preprints.provider.moderation' provider.id class="no-underline"}}
                     <small class="unread-label">{{pendingCount}}</small>
+                {{/link-to}}
+            </li>
+            <li>
+                {{#link-to 'preprints.provider.moderators' provider.id}}
+                    {{t 'global.moderators'}}
                 {{/link-to}}
             </li>
             <li>

--- a/app/components/provider-links/template.hbs
+++ b/app/components/provider-links/template.hbs
@@ -5,7 +5,7 @@
             {{placeholder.heading subtitle=false}}
         </span>
         <div class="provider-links">
-            <div class="provider-links--skeleton">{{placeholder.text lines=3}}</div>
+            <div class="provider-links--skeleton">{{placeholder.text lines=4}}</div>
         </div>
     {{/content-placeholders}}
 {{else}}

--- a/app/components/provider-links/template.hbs
+++ b/app/components/provider-links/template.hbs
@@ -17,7 +17,7 @@
         {{#if provider.reviewsWorkflow}}
             <li>
                 {{#link-to 'preprints.provider.moderation' provider.id}}
-                    {{t 'global.moderation'~}}
+                    {{t 'global.submissions'~}}
                 {{/link-to}}
                 {{#link-to 'preprints.provider.moderation' provider.id class="no-underline"}}
                     <small class="unread-label">{{pendingCount}}</small>

--- a/app/controllers/preprints/provider/moderators.js
+++ b/app/controllers/preprints/provider/moderators.js
@@ -32,6 +32,9 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
                 editingModerator: true,
                 addingNewModerator: true,
             });
+            if (this.get('page') !== this.get('results.totalPages')) {
+                this.set('page', this.get('results.totalPages'));
+            }
         },
     },
 
@@ -74,6 +77,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
         } catch (e) {
             this.get('toast').error(this.get('i18n').t('moderators.deleteModeratorError'));
         } finally {
+            yield this.get('fetchAdmin').perform();
             this.set('editingModerator', false);
         }
     }),
@@ -93,6 +97,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
             this.get('toast').error(this.get('i18n').t('moderators.updateModeratorError'));
             return false;
         } finally {
+            yield this.get('fetchAdmin').perform();
             this.set('editingModerator', false);
         }
     }),
@@ -120,6 +125,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
     }),
 
     fetchAdmin: task(function* () {
+        this.set('disableAdminDeletion', true);
         const provider = this.get('theme.provider');
         const admin = yield this.get('store').query('moderator', {
             provider: provider.id,
@@ -128,9 +134,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
             },
         });
 
-        if (admin.meta.total <= 1) {
-            this.set('disableAdminDeletion', true);
-        } else {
+        if (admin.meta.total > 1) {
             this.set('disableAdminDeletion', false);
         }
     }),

--- a/app/controllers/preprints/provider/moderators.js
+++ b/app/controllers/preprints/provider/moderators.js
@@ -39,6 +39,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
     },
 
     setup({ queryParams }) {
+        this.set('moderatorIds', []);
         this.set('roleOptions', [
             {
                 role: 'admin',
@@ -51,6 +52,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
         ]);
         this.get('fetchData').perform(queryParams);
         this.get('fetchAdmin').perform();
+        this.get('loadModerators').perform();
     },
 
     queryParamsDidChange({ shouldRefresh, queryParams }) {
@@ -64,6 +66,17 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
             this.resetQueryParams();
         }
     },
+
+    loadModerators: task(function* () {
+        const moderators = yield this.get('store').query('moderator', {
+            page: {
+                size: 100,
+            },
+            provider: this.get('theme.provider.id'),
+        });
+        const moderatorIds = moderators.map(moderator => moderator.id);
+        this.set('moderatorIds', moderatorIds);
+    }),
 
     deleteModerator: task(function* (id) {
         try {

--- a/app/controllers/preprints/provider/moderators.js
+++ b/app/controllers/preprints/provider/moderators.js
@@ -92,8 +92,20 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
             moderatorInstance.provider = this.get('theme.provider.id');
 
             yield moderatorInstance.destroyRecord({ adapterOptions: { provider: this.get('theme.provider.id') } });
+
+            const allModerators = yield this.get('store').peekAll('moderator');
+
+            if (allModerators.get('length') % 10 === 0) {
+                if (this.get('page') !== 1) {
+                    this.decrementProperty('page');
+                } else {
+                    yield this.get('fetchData').perform(this.get('queryParams'));
+                }
+            } else {
+                this.get('results.moderators').popObject(moderatorInstance);
+            }
+
             yield this.get('fetchAdmin').perform();
-            this.get('results.moderators').popObject(moderatorInstance);
             return true;
         } catch (e) {
             this.get('toast').error(this.get('i18n').t('moderators.deleteModeratorError'));
@@ -112,8 +124,10 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
                 },
             });
             moderatorInstance.set('permissionGroup', permissionGroup);
+
             yield moderatorInstance.save({ adapterOptions: { provider: this.get('theme.provider.id') } });
             yield this.get('fetchAdmin').perform();
+
             return true;
         } catch (e) {
             this.get('toast').error(this.get('i18n').t('moderators.updateModeratorError'));
@@ -144,8 +158,16 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
             }
 
             yield moderatorInstance.save();
+
+            const allModerators = yield this.get('store').peekAll('moderator');
+            // debugger;
+            if (allModerators.get('length') % 10 === 1) {
+                yield this.get('fetchData').perform(this.get('queryParams'));
+            } else {
+                this.get('results.moderators').pushObject(moderatorInstance);
+            }
+
             yield this.get('fetchAdmin').perform();
-            this.get('results.moderators').pushObject(moderatorInstance);
         } catch (e) {
             this.get('toast').error(this.get('i18n').t('moderators.addModeratorError'));
         } finally {

--- a/app/controllers/preprints/provider/moderators.js
+++ b/app/controllers/preprints/provider/moderators.js
@@ -160,7 +160,6 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
             yield moderatorInstance.save();
 
             const allModerators = yield this.get('store').peekAll('moderator');
-            // debugger;
             if (allModerators.get('length') % 10 === 1) {
                 yield this.get('fetchData').perform(this.get('queryParams'));
             } else {

--- a/app/controllers/preprints/provider/moderators.js
+++ b/app/controllers/preprints/provider/moderators.js
@@ -108,14 +108,25 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
         }
     }),
 
-    addModerator: task(function* (id, permissionGroup) {
+    addModerator: task(function* (id, permissionGroup, fullName) {
         try {
-            const moderatorInstance = yield this.get('store').createRecord('moderator', {
-                id,
-                permissionGroup,
-                // must include provider because ember data doesn't like the url structure
-                provider: this.get('theme.provider.id'),
-            });
+            let moderatorInstance = {};
+            if (fullName) {
+                moderatorInstance = yield this.get('store').createRecord('moderator', {
+                    permissionGroup,
+                    fullName,
+                    email: id,
+                    // must include provider because ember data doesn't like the url structure
+                    provider: this.get('theme.provider.id'),
+                });
+            } else {
+                moderatorInstance = yield this.get('store').createRecord('moderator', {
+                    id,
+                    permissionGroup,
+                    // must include provider because ember data doesn't like the url structure
+                    provider: this.get('theme.provider.id'),
+                });
+            }
 
             yield moderatorInstance.save();
             yield this.get('fetchAdmin').perform();

--- a/app/controllers/preprints/provider/moderators.js
+++ b/app/controllers/preprints/provider/moderators.js
@@ -83,6 +83,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
     deleteModerator: task(function* (moderatorInstance) {
         try {
             yield moderatorInstance.destroyRecord({ adapterOptions: { provider: this.get('theme.provider.id') } });
+            moderatorInstance.unloadRecord(); // https://github.com/emberjs/data/issues/5014
 
             const allModerators = this.get('store').peekAll('moderator');
 
@@ -102,6 +103,7 @@ export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
             this.get('toast').error(this.get('i18n').t('moderators.deleteModeratorError'));
             return false;
         } finally {
+            this.get('loadModerators').perform();
             this.set('editingModerator', false);
         }
     }),

--- a/app/controllers/preprints/provider/moderators.js
+++ b/app/controllers/preprints/provider/moderators.js
@@ -1,0 +1,110 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+import QueryParams from 'ember-parachute';
+import { task } from 'ember-concurrency';
+
+import Analytics from 'ember-osf/mixins/analytics';
+
+
+export const moderatorsQueryParams = new QueryParams({
+    page: {
+        defaultValue: 1,
+        refresh: true,
+    },
+});
+
+export default Controller.extend(Analytics, moderatorsQueryParams.Mixin, {
+    store: service(),
+    theme: service(),
+    i18n: service(),
+
+    disableAdminDeletion: false,
+    editingModerator: false,
+    addingNewContrib: false,
+
+    actions: {
+        pageChanged(page) {
+            this.set('page', page);
+        },
+        newModerator() {
+            this.setProperties({
+                editingModerator: true,
+                addingNewModerator: true,
+            });
+        },
+    },
+
+    setup({ queryParams }) {
+        this.set('roleOptions', [
+            {
+                role: 'admin',
+                label: 'Admin',
+            },
+            {
+                role: 'moderator',
+                label: 'Moderator',
+            },
+        ]);
+        this.get('fetchData').perform(queryParams);
+        this.get('fetchAdmin').perform(queryParams);
+    },
+
+    queryParamsDidChange({ shouldRefresh, queryParams }) {
+        if (shouldRefresh) {
+            this.get('fetchData').perform(queryParams);
+        }
+    },
+
+    reset(isExiting) {
+        if (isExiting) {
+            this.resetQueryParams();
+        }
+    },
+
+    saveModerator: task(function* (fullName, permissionGroup) {
+        try {
+            const moderatorInstance = yield this.get('store').createRecord('moderator', {
+                fullName,
+                permissionGroup,
+            });
+
+            yield moderatorInstance.save();
+            this.get('results.moderators').pushObject(moderatorInstance);
+        } catch (e) {
+            this.get('toast').error(this.get('i18n').t('components.preprintStatusBanner.error'));
+        } finally {
+            this.setProperties({
+                editingModerator: false,
+                addingNewModerator: false,
+            });
+        }
+    }),
+
+    fetchAdmin: task(function* () {
+        const provider = this.get('theme.provider');
+        const admin = yield this.get('store').query('moderator', {
+            provider: provider.id,
+            filter: {
+                permission_group: 'admin',
+            },
+        });
+
+        if (admin.meta.total <= 1) {
+            this.set('disableAdminDeletion', true);
+        }
+    }),
+
+    fetchData: task(function* (queryParams) {
+        const provider = this.get('theme.provider');
+        const response = yield this.get('store').query('moderator', {
+            provider: provider.id,
+            page: queryParams.page,
+        });
+
+        this.set('results', {
+            moderators: response.toArray(),
+            totalPages: Math.ceil(response.meta.total / response.meta.per_page),
+        });
+    }),
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -12,6 +12,40 @@ export default {
         settings: 'Settings',
         moderation: 'Moderation',
         notifications: 'Notifications',
+        submissions: 'Submissions',
+        moderators: 'Moderators',
+    },
+    documentType: {
+        default: {
+            plural: 'documents',
+            pluralCapitalized: 'Documents',
+            singular: 'document',
+            singularCapitalized: 'Document',
+        },
+        paper: {
+            plural: 'papers',
+            pluralCapitalized: 'Papers',
+            singular: 'paper',
+            singularCapitalized: 'Paper',
+        },
+        preprint: {
+            plural: 'preprints',
+            pluralCapitalized: 'Preprints',
+            singular: 'preprint',
+            singularCapitalized: 'Preprint',
+        },
+        none: {
+            plural: '',
+            pluralCapitalized: '',
+            singular: '',
+            singularCapitalized: '',
+        },
+        thesis: {
+            plural: 'theses',
+            pluralCapitalized: 'Theses',
+            singular: 'thesis',
+            singularCapitalized: 'Thesis',
+        },
     },
     index: {
         feature: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -1,6 +1,8 @@
 export default {
     global: {
         cancel: 'Cancel',
+        remove: 'Remove',
+        save: 'Save',
         abstract: 'Abstract',
         doi: 'DOI',
         tags: 'Tags',
@@ -65,6 +67,14 @@ export default {
                 postModeration: 'Post-moderation',
             },
         },
+    },
+    moderators: {
+        addNewMod: 'Add new moderator',
+        getStartedIntro: 'Get started by',
+        getStartedAction: 'adding a new moderator!',
+        deleteModeratorError: 'Error removing moderator.',
+        updateModeratorError: 'Error saving moderator',
+        addModeratorError: 'Error adding moderator',
     },
     providerSettings: {
         reviewsWorkflow: {
@@ -244,6 +254,13 @@ export default {
             daily: 'Daily',
             never: 'Never',
             errorUpdating: 'Error updating notification settings.',
+        },
+        moderatorListAdd: {
+            inviteText: 'invite by email',
+        },
+        moderatorList: {
+            editDisabledMessage: 'Can only edit one moderator at a time',
+            adminDisabledMessage: 'Must have one admin',
         },
         preprintStatusBanner: {
             recentActivity: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -258,6 +258,7 @@ export default {
         },
         moderatorListAdd: {
             inviteText: 'invite by email',
+            userSearchError: 'Error searching users.',
         },
         moderatorList: {
             editDisabledMessage: 'Can only edit one moderator at a time',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -3,6 +3,7 @@ export default {
         cancel: 'Cancel',
         remove: 'Remove',
         save: 'Save',
+        add: 'Add',
         abstract: 'Abstract',
         doi: 'DOI',
         tags: 'Tags',
@@ -324,6 +325,11 @@ export default {
                 },
             },
             error: 'Error submitting decision.',
+        },
+        unregisteredContributorForm: {
+            fullNameLabel: 'Full name',
+            emailLabel: 'Email',
+            notifyMessage: 'We will notify the user that they have been added as a moderator.',
         },
     },
 };

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -78,6 +78,8 @@ export default {
         addModeratorError: 'Error adding moderator',
         name: 'Name',
         permissions: 'Permissions',
+        admin: 'Admin',
+        moderator: 'Moderator',
     },
     providerSettings: {
         reviewsWorkflow: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -18,38 +18,6 @@ export default {
         submissions: 'Submissions',
         moderators: 'Moderators',
     },
-    documentType: {
-        default: {
-            plural: 'documents',
-            pluralCapitalized: 'Documents',
-            singular: 'document',
-            singularCapitalized: 'Document',
-        },
-        paper: {
-            plural: 'papers',
-            pluralCapitalized: 'Papers',
-            singular: 'paper',
-            singularCapitalized: 'Paper',
-        },
-        preprint: {
-            plural: 'preprints',
-            pluralCapitalized: 'Preprints',
-            singular: 'preprint',
-            singularCapitalized: 'Preprint',
-        },
-        none: {
-            plural: '',
-            pluralCapitalized: '',
-            singular: '',
-            singularCapitalized: '',
-        },
-        thesis: {
-            plural: 'theses',
-            pluralCapitalized: 'Theses',
-            singular: 'thesis',
-            singularCapitalized: 'Thesis',
-        },
-    },
     index: {
         feature: {
             title: 'Moderate your collection',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -70,7 +70,7 @@ export default {
         },
     },
     moderators: {
-        addNewMod: 'Add new moderator',
+        addNewMod: 'Add',
         getStartedIntro: 'Get started by',
         getStartedAction: 'adding a new moderator!',
         deleteModeratorError: 'Error removing moderator.',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -76,6 +76,8 @@ export default {
         deleteModeratorError: 'Error removing moderator.',
         updateModeratorError: 'Error saving moderator',
         addModeratorError: 'Error adding moderator',
+        name: 'Name',
+        permissions: 'Permissions',
     },
     providerSettings: {
         reviewsWorkflow: {

--- a/app/router.js
+++ b/app/router.js
@@ -55,6 +55,7 @@ Router.map(function() {
         this.route('provider', { path: ':provider_id' }, function() {
             this.route('setup');
             this.route('moderation', { path: '/' });
+            this.route('moderators');
             this.route('settings');
             this.route('preprint-detail', { path: ':preprint_id' });
             this.route('notifications');

--- a/app/styles/_util.scss
+++ b/app/styles/_util.scss
@@ -1,12 +1,12 @@
 .disabled {
+  opacity: .4;
   pointer-events: none;
-  opacity: 0.4;
 }
 
 .unread-label {
   background-color: $color-bg-gray-light;
   color: $color-text-gray-dark;
-  padding: 5px;
+  padding: 2px 5px;
   border-radius: 8px;
   font-weight: bold;
 }

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -76,6 +76,7 @@ $color-bg-dark-overlay: #343333;
 $color-bg-dark: #4c4c4c;
 $color-bg-blue-light: #ecf2f3;
 $color-bg-gray-light: #efefef;
+$color-bg-default: #f8f8f8;
 $color-bg-gray-cool: #f3f5f7;
 $color-bg-gray-lighter: $gray-lighter;
 $color-bg: #fcfcfc;

--- a/app/styles/modules/_provider.scss
+++ b/app/styles/modules/_provider.scss
@@ -1,3 +1,4 @@
 @import 'provider/settings';
 @import 'provider/setup';
+@import 'provider/moderators';
 @import 'provider/preprint-detail';

--- a/app/styles/modules/provider/_moderators.scss
+++ b/app/styles/modules/provider/_moderators.scss
@@ -7,7 +7,7 @@
   }
 
   .row-header {
-	  font-size: 18px;
+    font-size: 18px;
     align-self: flex-end;
   }
 }
@@ -28,7 +28,7 @@
 }
 
 .no-moderators-message {
-	text-align: center;
+  text-align: center;
 }
 
 .moderator-dropdown-menu {

--- a/app/styles/modules/provider/_moderators.scss
+++ b/app/styles/modules/provider/_moderators.scss
@@ -1,10 +1,14 @@
 .moderators-header {
-  display: flex;
-  justify-content: space-between;
   padding-bottom: 15px;
 
-  .page-title {
-	  font-size: 24px;
+  .add-moderator-button {
+    justify-self: flex-end;
+    align-self: flex-end;
+  }
+
+  .row-header {
+	  font-size: 18px;
+    align-self: flex-end;
   }
 }
 

--- a/app/styles/modules/provider/_moderators.scss
+++ b/app/styles/modules/provider/_moderators.scss
@@ -4,11 +4,20 @@
   padding-bottom: 15px;
 
   .page-title {
-	font-size: 24px;
+	  font-size: 24px;
   }
 }
 
-.row-border {
+.moderators-row-container {
+  display: inline-grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  align-items: center;
+  justify-items: start;
+  width: 100%;
+  min-height: 60px;
+}
+
+.moderators-row-border {
   width: 100%;
   height: 1px;
   background-color: $color-border-gray-light;
@@ -30,5 +39,46 @@
 
   li:hover {
     background-color: $color-border-gray-light;
+  }
+}
+
+.moderators-row--skeleton {
+  .dropdown--skeleton {
+    width: 115px;
+
+    .ember-content-placeholders-img {
+      height: 32px;
+    }
+  }
+
+  .remove-icon--skeleton {
+    justify-self: end;
+  }
+}
+
+.name--skeleton {
+  width: 100%;
+
+  > div {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+  }
+
+  .ember-content-placeholders-text {
+    width: 150px;
+  }
+
+  .ember-content-placeholders-text__line {
+    margin-bottom: 0;
+  }
+
+  .gravatar--skeleton {
+    width: 30px;
+
+    .ember-content-placeholders-img {
+      height: 30px;
+    }
   }
 }

--- a/app/styles/modules/provider/_moderators.scss
+++ b/app/styles/modules/provider/_moderators.scss
@@ -1,0 +1,34 @@
+.moderators-header {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 15px;
+
+  .page-title {
+	font-size: 24px;
+  }
+}
+
+.row-border {
+  width: 100%;
+  height: 1px;
+  background-color: $color-border-gray-light;
+}
+
+.no-moderators-message {
+	text-align: center;
+}
+
+.moderator-dropdown-menu {
+  background-color: $color-bg-default;
+
+  button {
+    display: flex;
+    justify-content: space-between;
+    background: transparent;
+    width: 100%;
+  }
+
+  li:hover {
+    background-color: $color-border-gray-light;
+  }
+}

--- a/app/styles/modules/provider/_preprint-detail.scss
+++ b/app/styles/modules/provider/_preprint-detail.scss
@@ -103,12 +103,6 @@ ul.comma-list {
       min-height: 100px;
     }
   }
-
-  .disabled {
-    cursor: no-drop;
-    opacity: .4;
-    pointer-events: none;
-  }
 }
 
 .content-provider-logo {

--- a/app/templates/preprints/provider/moderators.hbs
+++ b/app/templates/preprints/provider/moderators.hbs
@@ -1,0 +1,39 @@
+<div class="content container">
+    <div class="moderators-header m-t-lg">
+        <div class="page-title">{{theme.provider.name}} {{t "global.moderators"}}</div>
+        <button class="btn btn-default add-moderator-button" {{action 'newModerator'}}>
+            <i class="fa fa-plus p-r-xs"></i>
+            Add new moderator
+        </button>
+    </div>
+    <div class="row-border"></div>
+    {{#if (or fetchData.isRunning fetchAdmin.isRunning)}}
+        <div class="row-container p-h-md p-v-sm">
+            {{#content-placeholders as |placeholder|}}
+                {{placeholder.text lines=1}}
+            {{/content-placeholders}}
+        </div>
+        <div class="row-border"></div>
+    {{else if (not results.moderators)}}
+        <p class="m-b-md m-t-md no-moderators-message">
+            Get started by <a>adding a new moderator</a>!
+        </p>
+        <div class="row-border"></div>
+    {{else}}
+        {{#each results.moderators as |moderator|}}
+            {{moderator-list-row
+                moderator=moderator
+                disableAdminDeletion=disableAdminDeletion
+                editingModerator=editingModerator
+                roleOptions=roleOptions
+            }}
+        {{/each}}
+        {{#if addingNewModerator}}
+            {{moderator-list-add
+                roleOptions=roleOptions
+                addingNewModerator=addingNewModerator
+                saveModerator=(perform saveModerator)
+            }}
+        {{/if}}
+    {{/if}}
+</div>

--- a/app/templates/preprints/provider/moderators.hbs
+++ b/app/templates/preprints/provider/moderators.hbs
@@ -7,7 +7,7 @@
         </button>
     </div>
     <div class="moderators-row-border"></div>
-    {{#if (or fetchData.isRunning fetchAdmin.isRunning)}}
+    {{#if (or fetchData.isRunning)}}
         <div class="moderators-row-container moderators-row--skeleton p-h-md p-v-sm">
             <div class="name--skeleton">
                 {{#content-placeholders as |placeholder|}}
@@ -51,5 +51,13 @@
                 addModerator=addModerator
             }}
         {{/if}}
+        <div class="pull-right text-right">
+            {{pagination-pager
+                count=results.totalPages
+                current=page
+                change=(action 'pageChanged')
+            }}
+        </div>
     {{/if}}
+    <div class="p-b-lg"></div>
 </div>

--- a/app/templates/preprints/provider/moderators.hbs
+++ b/app/templates/preprints/provider/moderators.hbs
@@ -49,6 +49,8 @@
                 editingModerator=editingModerator
                 addingNewModerator=addingNewModerator
                 addModerator=addModerator
+                moderatorIds=moderatorIds
+                loadingModerators=loadModerators.isRunning
             }}
         {{/if}}
         <div class="pull-right text-right">

--- a/app/templates/preprints/provider/moderators.hbs
+++ b/app/templates/preprints/provider/moderators.hbs
@@ -1,10 +1,13 @@
 <div class="content container">
-    <div class="moderators-header m-t-lg">
-        <div class="page-title">{{theme.provider.name}} {{t 'global.moderators'}}</div>
-        <button class="btn btn-default add-moderator-button" {{action 'newModerator'}} disabled={{editingModerator}}>
-            <i class="fa fa-plus p-r-xs"></i>
-            {{t 'moderators.addNewMod'}}
-        </button>
+    <div class="moderators-header moderators-row-container m-t-md">
+        <div class="row-header p-l-md">{{t 'moderators.name'}}</div>
+        {{#if isAdmin}}
+            <div class="row-header">{{t 'moderators.permissions'}}</div>
+            <button class="btn btn-default add-moderator-button m-r-md" {{action 'newModerator'}} disabled={{editingModerator}}>
+                <i class="fa fa-plus p-r-xs"></i>
+                {{t 'moderators.addNewMod'}}
+            </button>
+        {{/if}}
     </div>
     <div class="moderators-row-border"></div>
     {{#if fetchData.isRunning}}
@@ -15,16 +18,18 @@
                     <div class="m-l-sm">{{placeholder.text lines=1}}</div>
                 {{/content-placeholders}}
             </div>
-            <div>
-                {{#content-placeholders as |placeholder|}}
-                    <div class="dropdown--skeleton">{{placeholder.img}}</div>
-                {{/content-placeholders}}
-            </div>
-            <div class="remove-icon--skeleton">
-                {{#content-placeholders as |placeholder|}}
-                    {{placeholder.icon}}
-                {{/content-placeholders}}
-            </div>
+            {{#if isAdmin}}
+                <div>
+                    {{#content-placeholders as |placeholder|}}
+                        <div class="dropdown--skeleton">{{placeholder.img}}</div>
+                    {{/content-placeholders}}
+                </div>
+                <div class="remove-icon--skeleton">
+                    {{#content-placeholders as |placeholder|}}
+                        {{placeholder.icon}}
+                    {{/content-placeholders}}
+                </div>
+            {{/if}}
         </div>
         <div class="moderators-row-border"></div>
     {{else if (not results.moderators)}}
@@ -36,6 +41,7 @@
         {{#each results.moderators as |moderator|}}
             {{moderator-list-row
                 moderator=moderator
+                isAdmin=isAdmin
                 disableAdminDeletion=disableAdminDeletion
                 editingModerator=editingModerator
                 updateModerator=updateModerator

--- a/app/templates/preprints/provider/moderators.hbs
+++ b/app/templates/preprints/provider/moderators.hbs
@@ -1,7 +1,7 @@
 <div class="content container">
     <div class="moderators-header m-t-lg">
         <div class="page-title">{{theme.provider.name}} {{t 'global.moderators'}}</div>
-        <button class="btn btn-default add-moderator-button" {{action 'newModerator'}}>
+        <button class="btn btn-default add-moderator-button" {{action 'newModerator'}} disabled={{editingModerator}}>
             <i class="fa fa-plus p-r-xs"></i>
             {{t 'moderators.addNewMod'}}
         </button>

--- a/app/templates/preprints/provider/moderators.hbs
+++ b/app/templates/preprints/provider/moderators.hbs
@@ -7,7 +7,7 @@
         </button>
     </div>
     <div class="moderators-row-border"></div>
-    {{#if (or fetchData.isRunning)}}
+    {{#if fetchData.isRunning}}
         <div class="moderators-row-container moderators-row--skeleton p-h-md p-v-sm">
             <div class="name--skeleton">
                 {{#content-placeholders as |placeholder|}}

--- a/app/templates/preprints/provider/moderators.hbs
+++ b/app/templates/preprints/provider/moderators.hbs
@@ -1,38 +1,54 @@
 <div class="content container">
     <div class="moderators-header m-t-lg">
-        <div class="page-title">{{theme.provider.name}} {{t "global.moderators"}}</div>
+        <div class="page-title">{{theme.provider.name}} {{t 'global.moderators'}}</div>
         <button class="btn btn-default add-moderator-button" {{action 'newModerator'}}>
             <i class="fa fa-plus p-r-xs"></i>
-            Add new moderator
+            {{t 'moderators.addNewMod'}}
         </button>
     </div>
-    <div class="row-border"></div>
+    <div class="moderators-row-border"></div>
     {{#if (or fetchData.isRunning fetchAdmin.isRunning)}}
-        <div class="row-container p-h-md p-v-sm">
-            {{#content-placeholders as |placeholder|}}
-                {{placeholder.text lines=1}}
-            {{/content-placeholders}}
+        <div class="moderators-row-container moderators-row--skeleton p-h-md p-v-sm">
+            <div class="name--skeleton">
+                {{#content-placeholders as |placeholder|}}
+                    <div class="gravatar--skeleton">{{placeholder.img}}</div>
+                    <div class="m-l-sm">{{placeholder.text lines=1}}</div>
+                {{/content-placeholders}}
+            </div>
+            <div>
+                {{#content-placeholders as |placeholder|}}
+                    <div class="dropdown--skeleton">{{placeholder.img}}</div>
+                {{/content-placeholders}}
+            </div>
+            <div class="remove-icon--skeleton">
+                {{#content-placeholders as |placeholder|}}
+                    {{placeholder.icon}}
+                {{/content-placeholders}}
+            </div>
         </div>
-        <div class="row-border"></div>
+        <div class="moderators-row-border"></div>
     {{else if (not results.moderators)}}
         <p class="m-b-md m-t-md no-moderators-message">
-            Get started by <a>adding a new moderator</a>!
+            {{t 'getStartedIntro'}} <a>{{t 'getStartedAction'}}</a>!
         </p>
-        <div class="row-border"></div>
+        <div class="moderator-row-border"></div>
     {{else}}
         {{#each results.moderators as |moderator|}}
             {{moderator-list-row
                 moderator=moderator
                 disableAdminDeletion=disableAdminDeletion
                 editingModerator=editingModerator
+                updateModerator=updateModerator
+                deleteModerator=deleteModerator
                 roleOptions=roleOptions
             }}
         {{/each}}
         {{#if addingNewModerator}}
             {{moderator-list-add
                 roleOptions=roleOptions
+                editingModerator=editingModerator
                 addingNewModerator=addingNewModerator
-                saveModerator=(perform saveModerator)
+                addModerator=addModerator
             }}
         {{/if}}
     {{/if}}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ember-moment": "^7.4.1",
     "ember-onbeforeunload": "^1.1.2",
     "ember-parachute": "^0.3.5",
+    "ember-power-select": "^1.10.4",
     "ember-radio-button": "^1.1.1",
     "ember-resolver": "^4.0.0",
     "ember-source": "2.16.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-component-css": "^0.3.5",
     "ember-concurrency": "^0.8.12",
+    "ember-cp-validations": "^3.5.2",
     "ember-data": "2.16.2",
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "use-ember-osf-next-interfaces": "yarn upgrade @centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#release/next-interfaces#$(date -u +%FT%TZ)"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "0.16.0",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#release/next-interfaces#2018-05-02T13:56:01Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@cos-forks/ember-content-placeholders": "https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc",
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/acceptance/preprints/providers/moderators-test.js
+++ b/tests/acceptance/preprints/providers/moderators-test.js
@@ -1,0 +1,64 @@
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import RSVP from 'rsvp';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../../helpers/module-for-acceptance';
+
+
+moduleForAcceptance('Acceptance | preprints/providers/moderators');
+
+const sessionAuthenticatedStub = Service.extend({
+    isAuthenticated() {
+        return true;
+    },
+});
+
+const sessionStub = Service.extend({
+    authenticate() {
+        return RSVP.reject('');
+    },
+    isAuthenticated: false,
+});
+
+const currentAdminUserStub = Service.extend({
+    user: RSVP.resolve(EmberObject.create({ canViewReviews: true })),
+});
+
+const currentUserStub = Service.extend({
+    user: RSVP.resolve(EmberObject.create({ canViewReviews: false })),
+});
+
+test('visiting /moderators not authenticated', function(assert) {
+    this.application.register('service:session-service', sessionStub);
+    this.application.inject('route:application', 'session', 'service:session-service');
+
+    visit('/moderators');
+
+    andThen(function() {
+        assert.equal(currentURL(), '/');
+    });
+});
+
+test('visiting /moderators authenticated', function(assert) {
+    this.application.register('service:session-service', sessionAuthenticatedStub);
+    this.application.inject('route:application', 'session', 'service:session-service');
+    this.application.register('service:currentUser-service', currentUserStub);
+    this.application.inject('route:application', 'currentUser', 'service:currentUser-service');
+    visit('/moderators');
+
+    andThen(function() {
+        assert.equal(currentURL(), '/');
+    });
+});
+
+test('visiting /moderators authenticated', function(assert) {
+    this.application.register('service:session-service', sessionAuthenticatedStub);
+    this.application.inject('route:application', 'session', 'service:session-service');
+    this.application.register('service:currentUser-service', currentAdminUserStub);
+    this.application.inject('route:application', 'currentUser', 'service:currentUser-service');
+    visit('/moderators');
+
+    andThen(function() {
+        assert.equal(currentURL(), '/moderators');
+    });
+});

--- a/tests/integration/components/moderator-list-add/component-test.js
+++ b/tests/integration/components/moderator-list-add/component-test.js
@@ -1,0 +1,78 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
+
+
+moduleForComponent('moderator-list-add', 'Integration | Component | moderator-list-add', {
+    integration: true,
+});
+
+test('it renders moderator-list-add form no input', function(assert) {
+    this.set('roleOptions', [
+        {
+            role: 'admin',
+            label: 'Admin',
+        },
+        {
+            role: 'moderator',
+            label: 'Moderator',
+        },
+    ]);
+    this.set('addModerator', function() { return true; });
+    this.set('moderatorIds', ['12345']);
+
+    this.render(hbs`{{moderator-list-add
+                editingModerator=true
+                addModerator=addModerator
+                addingNewModerator=true
+                moderatorIds=moderatorIds
+                loadingModerators=false
+                roleOptions=roleOptions
+            }}`);
+
+    assert.ok(this.$('.ember-basic-dropdown-trigger').length);
+    assert.ok(this.$('.dropdown-button').length);
+    assert.ok(this.$('.row-controls').length);
+    assert.ok(this.$('.row-controls > button[disabled].btn-success').length);
+    assert.ok(this.$('.dropdown-link').length);
+
+    assert.notOk(this.$('.invite-dropdown.open').length);
+
+    assert.equal(this.$('.dropdown-button').text().replace(/\s+/g, ' ').trim(), 'Role');
+});
+
+test('it renders moderator-list-add form valid input', function(assert) {
+    this.set('roleOptions', [
+        {
+            role: 'admin',
+            label: 'Admin',
+        },
+        {
+            role: 'moderator',
+            label: 'Moderator',
+        },
+    ]);
+    this.set('addModerator', function() { return true; });
+    this.set('moderatorIds', ['12345']);
+
+    this.render(hbs`{{moderator-list-add
+                editingModerator=true
+                addModerator=addModerator
+                addingNewModerator=true
+                moderatorIds=moderatorIds
+                loadingModerators=false
+                roleOptions=roleOptions
+            }}`);
+
+    run(() => document.querySelector('#toggle-form').click());
+
+    assert.ok(this.$('.ember-basic-dropdown-trigger').length);
+    assert.ok(this.$('.dropdown-button').length);
+    assert.ok(this.$('.row-controls').length);
+    assert.ok(this.$('.row-controls > button[disabled].btn-success').length);
+    assert.ok(this.$('.dropdown-link').length);
+
+    assert.ok(this.$('.invite-dropdown.open').length);
+
+    assert.equal(this.$('.dropdown-button').text().replace(/\s+/g, ' ').trim(), 'Role');
+});

--- a/tests/integration/components/moderator-list-row/component-test.js
+++ b/tests/integration/components/moderator-list-row/component-test.js
@@ -1,0 +1,202 @@
+import EmberObject from '@ember/object';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+
+const storeStub = Service.extend({
+    findRecord() {
+        const user = {
+            links: {
+                profile_image: 'https://gravator.com/1234/',
+                html: 'https://localhost:5000/12345/',
+            },
+        };
+        return user;
+    },
+});
+
+moduleForComponent('moderator-list-row', 'Integration | Component | moderator-list-row', {
+    integration: true,
+
+    beforeEach() {
+        this.register('service:store', storeStub);
+        this.inject.service('store');
+    },
+});
+
+test('it renders moderator-list-row admin view', function(assert) {
+    this.set('roleOptions', [
+        {
+            role: 'admin',
+            label: 'Admin',
+        },
+        {
+            role: 'moderator',
+            label: 'Moderator',
+        },
+    ]);
+    this.set('updateModerator', function() { return true; });
+    this.set('deleteModerator', function() { return true; });
+    this.set('moderator', {
+        permissionGroup: 'admin',
+        fullName: 'Brian Nosek',
+        id: '12345',
+    });
+    this.render(hbs`{{moderator-list-row
+                moderator=moderator
+                isAdmin=true
+                disableAdminDeletion=false
+                editingModerator=false
+                updateModerator=updateModerator
+                deleteModerator=deleteModerator
+                roleOptions=roleOptions
+            }}`);
+    assert.ok(this.$('.moderator-name').length);
+    assert.ok(this.$('.dropdown-button').length);
+    assert.ok(this.$('.row-controls').length);
+    assert.notOk(this.$('.remove-button.disabled').length);
+
+    assert.equal(this.$('.moderator-name > .name').text().replace(/\s+/g, ' ').trim(), 'Brian Nosek');
+    assert.equal(this.$('.dropdown-button').text().replace(/\s+/g, ' ').trim(), 'Admin');
+});
+
+test('it renders moderator-list-row admin view remove disabled for admin', function(assert) {
+    this.set('roleOptions', [
+        {
+            role: 'admin',
+            label: 'Admin',
+        },
+        {
+            role: 'moderator',
+            label: 'Moderator',
+        },
+    ]);
+    this.set('updateModerator', function() { return true; });
+    this.set('deleteModerator', function() { return true; });
+    this.set('moderator', {
+        permissionGroup: 'admin',
+        fullName: 'Brian Nosek',
+        id: '12345',
+    });
+    this.render(hbs`{{moderator-list-row
+                moderator=moderator
+                isAdmin=true
+                disableAdminDeletion=true
+                editingModerator=false
+                updateModerator=updateModerator
+                deleteModerator=deleteModerator
+                roleOptions=roleOptions
+            }}`);
+    assert.ok(this.$('.moderator-name').length);
+    assert.ok(this.$('.dropdown-button').length);
+    assert.ok(this.$('.row-controls').length);
+    assert.ok(this.$('.remove-button.disabled').length);
+
+    assert.equal(this.$('.moderator-name > .name').text().replace(/\s+/g, ' ').trim(), 'Brian Nosek');
+    assert.equal(this.$('.dropdown-button').text().replace(/\s+/g, ' ').trim(), 'Admin');
+});
+
+test('it renders moderator-list-row admin view remove not disabled for mod', function(assert) {
+    this.set('roleOptions', [
+        {
+            role: 'admin',
+            label: 'Admin',
+        },
+        {
+            role: 'moderator',
+            label: 'Moderator',
+        },
+    ]);
+    this.set('updateModerator', function() { return true; });
+    this.set('deleteModerator', function() { return true; });
+    this.set('moderator', {
+        permissionGroup: 'moderator',
+        fullName: 'Brian Nosek',
+        id: '12345',
+    });
+    this.render(hbs`{{moderator-list-row
+                moderator=moderator
+                isAdmin=true
+                disableAdminDeletion=true
+                editingModerator=false
+                updateModerator=updateModerator
+                deleteModerator=deleteModerator
+                roleOptions=roleOptions
+            }}`);
+    assert.ok(this.$('.moderator-name').length);
+    assert.ok(this.$('.dropdown-button').length);
+    assert.ok(this.$('.row-controls').length);
+    assert.notOk(this.$('.remove-button.disabled').length);
+
+    assert.equal(this.$('.moderator-name > .name').text().replace(/\s+/g, ' ').trim(), 'Brian Nosek');
+    assert.equal(this.$('.dropdown-button').text().replace(/\s+/g, ' ').trim(), 'Moderator');
+});
+
+test('it renders moderator-list-row admin view remove disabled for mod', function(assert) {
+    this.set('roleOptions', [
+        {
+            role: 'admin',
+            label: 'Admin',
+        },
+        {
+            role: 'moderator',
+            label: 'Moderator',
+        },
+    ]);
+    this.set('updateModerator', function() { return true; });
+    this.set('deleteModerator', function() { return true; });
+    this.set('moderator', {
+        permissionGroup: 'moderator',
+        fullName: 'Brian Nosek',
+        id: '12345',
+    });
+    this.render(hbs`{{moderator-list-row
+                moderator=moderator
+                isAdmin=true
+                disableAdminDeletion=false
+                editingModerator=true
+                updateModerator=updateModerator
+                deleteModerator=deleteModerator
+                roleOptions=roleOptions
+            }}`);
+    assert.ok(this.$('.moderator-name').length);
+    assert.ok(this.$('.dropdown-button').length);
+    assert.ok(this.$('.row-controls').length);
+    assert.ok(this.$('.remove-button.disabled').length);
+
+    assert.equal(this.$('.moderator-name > .name').text().replace(/\s+/g, ' ').trim(), 'Brian Nosek');
+    assert.equal(this.$('.dropdown-button').text().replace(/\s+/g, ' ').trim(), 'Moderator');
+});
+
+test('it renders moderator-list-row moderator view', function(assert) {
+    this.set('roleOptions', [
+        {
+            role: 'admin',
+            label: 'Admin',
+        },
+        {
+            role: 'moderator',
+            label: 'Moderator',
+        },
+    ]);
+    this.set('updateModerator', function() { return true; });
+    this.set('deleteModerator', function() { return true; });
+    this.set('moderator', EmberObject.create({
+        permissionGroup: 'moderator',
+        fullName: 'Brian Nosek',
+        id: '12345',
+    }));
+    this.render(hbs`{{moderator-list-row
+                moderator=moderator
+                isAdmin=false
+                disableAdminDeletion=false
+                editingModerator=false
+                updateModerator=updateModerator
+                deleteModerator=deleteModerator
+                roleOptions=roleOptions
+            }}`);
+    assert.ok(this.$('.moderator-name').length);
+    assert.notOk(this.$('.dropdown-button').length);
+    assert.notOk(this.$('.row-controls').length);
+});

--- a/tests/unit/components/moderator-list-add-test.js
+++ b/tests/unit/components/moderator-list-add-test.js
@@ -1,0 +1,110 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+
+moduleForComponent('moderator-list-add', 'Unit | Component | moderator list add', {
+    unit: true,
+    needs: [
+        'service:i18n',
+        'service:theme',
+        'validator:presence',
+        'validator:length',
+        'validator:format',
+    ],
+});
+
+test('roleLabel computed property', function(assert) {
+    const component = this.subject({
+        roleOptions: [
+            {
+                role: 'admin',
+                label: 'Admin',
+            },
+            {
+                role: 'moderator',
+                label: 'Moderator',
+            },
+        ],
+    });
+    assert.ok(component);
+
+    component.set('role', 'admin');
+    assert.strictEqual(component.get('roleLabel'), 'Admin');
+
+    component.set('role', 'moderator');
+    assert.strictEqual(component.get('roleLabel'), 'Moderator');
+});
+
+test('selectedUserId computed property', function(assert) {
+    const component = this.subject({
+        selectedUser: { id: 12345 },
+        unregisteredUserEmail: '',
+    });
+    assert.ok(component);
+
+    assert.strictEqual(component.get('selectedUserId'), 12345);
+
+    component.set('selectedUser', '');
+    component.set('unregisteredUserEmail', 'testuser@gmail.com');
+    assert.strictEqual(component.get('selectedUserId'), 'testuser@gmail.com');
+});
+
+test('disableSave computed property', function(assert) {
+    const component = this.subject({
+        role: '',
+        selectedUser: '',
+        unregisteredUserName: '',
+    });
+    assert.ok(component);
+    assert.strictEqual(component.get('disableSave'), true);
+
+    component.set('selectedUser', { id: 12345 });
+    assert.strictEqual(component.get('disableSave'), true);
+
+    component.set('role', 'admin');
+    assert.strictEqual(component.get('disableSave'), false);
+
+    component.set('unregisteredUserName', 'Test User');
+    component.set('selectedUser', '');
+    assert.strictEqual(component.get('disableSave'), false);
+});
+
+test('showInviteForm computed property', function(assert) {
+    const component = this.subject({
+        selectedUser: '',
+        selectedUnregisteredUser: false,
+    });
+    assert.ok(component);
+    assert.strictEqual(component.get('showInviteForm'), true);
+
+    component.set('selectedUser', { id: 12345 });
+    assert.strictEqual(component.get('showInviteForm'), false);
+
+    component.set('selectedUnregisteredUser', true);
+    component.set('selectedUser', '');
+    assert.strictEqual(component.get('showInviteForm'), false);
+});
+
+test('roleChanged action', function (assert) {
+    const component = this.subject();
+
+    component.set('role', 'admin');
+
+    component.send('roleChanged', 'moderator');
+    assert.strictEqual(component.get('role'), 'moderator');
+});
+
+test('cancel action', function (assert) {
+    const component = this.subject();
+
+    component.set('role', 'moderator');
+    component.set('selectedUser', { id: 12345 });
+    component.set('editingModerator', true);
+    component.set('addingNewModerator', true);
+
+    component.send('cancel');
+
+    assert.strictEqual(component.get('role'), '');
+    assert.strictEqual(component.get('selectedUser'), '');
+    assert.strictEqual(component.get('editingModerator'), false);
+    assert.strictEqual(component.get('addingNewModerator'), false);
+});

--- a/tests/unit/components/moderator-list-row-test.js
+++ b/tests/unit/components/moderator-list-row-test.js
@@ -1,0 +1,67 @@
+import { run } from '@ember/runloop';
+
+import { moduleForComponent, test } from 'ember-qunit';
+
+
+moduleForComponent('moderator-list-row', 'Unit | Component | moderator list row', {
+    // Specify the other units that are required for this test
+    // needs: ['component:foo', 'helper:bar'],
+    unit: true,
+    needs: [
+        'model:user',
+        'service:i18n',
+        'service:metrics',
+    ],
+});
+
+test('roleChanged action', function (assert) {
+    this.inject.service('store');
+    const component = this.subject({ moderator: { id: 12345 } });
+
+    run(() => {
+        component.set('role', 'admin');
+        component.set('editingModerator', false);
+        component.set('editConfirmation', false);
+
+        component.send('roleChanged', 'moderator');
+
+        assert.strictEqual(component.get('role'), 'moderator');
+        assert.strictEqual(component.get('editingModerator'), true);
+        assert.strictEqual(component.get('editConfirmation'), true);
+    });
+});
+
+test('removeInitiated action', function (assert) {
+    this.inject.service('store');
+    const component = this.subject({ moderator: { id: 12345 } });
+
+    run(() => {
+        component.set('editingModerator', false);
+        component.set('removeConfirmation', false);
+
+        component.send('removeInitiated');
+
+        assert.strictEqual(component.get('editingModerator'), true);
+        assert.strictEqual(component.get('removeConfirmation'), true);
+    });
+});
+
+test('cancel action', function (assert) {
+    this.inject.service('store');
+    const component = this.subject({ moderator: { id: 12345 } });
+
+    run(() => {
+        component.set('moderator.permissionGroup', 'admin');
+        component.set('role', 'moderator');
+        component.set('editingModerator', true);
+        component.set('removeConfirmation', true);
+        component.set('editConfirmation', true);
+
+        component.send('cancel');
+
+        assert.strictEqual(component.get('role'), 'admin');
+        assert.strictEqual(component.get('editingModerator'), false);
+        assert.strictEqual(component.get('removeConfirmation'), false);
+        assert.strictEqual(component.get('editConfirmation'), false);
+    });
+});

--- a/tests/unit/controllers/preprints/provider/moderators-test.js
+++ b/tests/unit/controllers/preprints/provider/moderators-test.js
@@ -24,7 +24,7 @@ test('Initial properties', function (assert) {
     assert.ok(propKeys.every(key => expected[key] === actual[key]));
 });
 
-test('pageChange action', function (assert) {
+test('pageChanged action', function (assert) {
     const ctrl = this.subject();
     ctrl.set('page', 2);
 

--- a/tests/unit/controllers/preprints/provider/moderators-test.js
+++ b/tests/unit/controllers/preprints/provider/moderators-test.js
@@ -1,0 +1,67 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+moduleFor('controller:preprints/provider/moderators', 'Unit | Controller | preprints/provider/moderators', {
+    // Specify the other units that are required for this test.
+    needs: [
+        'service:theme',
+        'service:currentUser',
+        'service:metrics',
+        'service:i18n',
+    ],
+});
+
+test('Initial properties', function (assert) {
+    const ctrl = this.subject();
+
+    const expected = {
+        page: 1,
+    };
+
+    const propKeys = Object.keys(expected);
+    const actual = ctrl.getProperties(propKeys);
+
+    assert.ok(propKeys.every(key => expected[key] === actual[key]));
+});
+
+test('pageChange action', function (assert) {
+    const ctrl = this.subject();
+    ctrl.set('page', 2);
+
+    ctrl.send('pageChanged', 1);
+
+    assert.strictEqual(ctrl.get('page'), 1);
+});
+
+test('newModerator action', function (assert) {
+    const ctrl = this.subject();
+    ctrl.set('page', 1);
+    ctrl.set('results', { totalPages: 2 });
+    ctrl.set('editingModerator', false);
+    ctrl.set('addingNewModerator', false);
+
+    ctrl.send('newModerator');
+
+    assert.strictEqual(ctrl.get('page'), 2);
+    assert.strictEqual(ctrl.get('editingModerator'), true);
+    assert.strictEqual(ctrl.get('addingNewModerator'), true);
+});
+
+test('Reset properties', function (assert) {
+    const ctrl = this.subject();
+
+    const expected = {
+        page: 1,
+    };
+
+    ctrl.setProperties({
+        page: 2,
+    });
+
+    ctrl.reset(true);
+
+    const propKeys = Object.keys(expected);
+    const actual = ctrl.getProperties(propKeys);
+
+    assert.ok(propKeys.every(key => expected[key] === actual[key]));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3336,6 +3336,19 @@ ember-cookies@^0.0.13:
     ember-getowner-polyfill "^1.2.2"
 
 ember-cp-validations@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/ember-cp-validations/-/ember-cp-validations-3.5.3.tgz#059d173e2f0904232516b23c4b774675e672ae11"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-version-checker "^2.0.0"
+    ember-getowner-polyfill "^2.0.1"
+    ember-require-module "0.1.3"
+    ember-string-ishtmlsafe-polyfill "^2.0.0"
+    ember-validators "1.0.4"
+    exists-sync "0.0.4"
+    walk-sync "^0.3.1"
+
+ember-cp-validations@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ember-cp-validations/-/ember-cp-validations-3.5.2.tgz#1b205891ae7d7026f7b6c55cf6e440122db9b2ac"
   dependencies:
@@ -3663,7 +3676,7 @@ ember-require-module@0.1.2:
   dependencies:
     ember-cli-babel "^5.1.7"
 
-ember-require-module@^0.1.2:
+ember-require-module@0.1.3, ember-require-module@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.1.3.tgz#f82f60552142179152d28ec97ebd75d967cae1dc"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@0.16.0":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#release/next-interfaces#2018-05-02T13:56:01Z":
   version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/ember-osf/-/ember-osf-0.16.0.tgz#197951a4f567fe8b21d470eeb884012595f02abd"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#8a54a7ea41c269dfe95f018185c7873c3abec0c9"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
@@ -72,6 +72,7 @@
     ember-cli-shims "1.0.2"
     ember-collapsible-panel "^2.1.1"
     ember-component-css "^0.6.0"
+    ember-computed-style "^0.2.0"
     ember-concurrency "^0.8.12"
     ember-cp-validations "^3.5.0"
     ember-diff-attrs "^0.2.0"
@@ -3318,6 +3319,12 @@ ember-component-css@^0.6.0:
     postcss-selector-namespace "^1.5.0"
     rsvp "^4.8.1"
     walk-sync "^0.3.2"
+
+ember-computed-style@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-computed-style/-/ember-computed-style-0.2.0.tgz#6ceb2f1f10f9555fa5b5092f5668dde2c9df5440"
+  dependencies:
+    ember-cli-babel "^5.1.7"
 
 ember-concurrency@^0.8.12:
   version "0.8.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3335,20 +3335,7 @@ ember-cookies@^0.0.13:
     ember-cli-babel "^5.1.7"
     ember-getowner-polyfill "^1.2.2"
 
-ember-cp-validations@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/ember-cp-validations/-/ember-cp-validations-3.5.3.tgz#059d173e2f0904232516b23c4b774675e672ae11"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-    ember-cli-version-checker "^2.0.0"
-    ember-getowner-polyfill "^2.0.1"
-    ember-require-module "0.1.3"
-    ember-string-ishtmlsafe-polyfill "^2.0.0"
-    ember-validators "1.0.4"
-    exists-sync "0.0.4"
-    walk-sync "^0.3.1"
-
-ember-cp-validations@^3.5.2:
+ember-cp-validations@^3.5.0, ember-cp-validations@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ember-cp-validations/-/ember-cp-validations-3.5.2.tgz#1b205891ae7d7026f7b6c55cf6e440122db9b2ac"
   dependencies:
@@ -3676,7 +3663,7 @@ ember-require-module@0.1.2:
   dependencies:
     ember-cli-babel "^5.1.7"
 
-ember-require-module@0.1.3, ember-require-module@^0.1.2:
+ember-require-module@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.1.3.tgz#f82f60552142179152d28ec97ebd75d967cae1dc"
   dependencies:


### PR DESCRIPTION
## TODO
- [x] get adding a new moderator working
- [x] get removing moderator working
- [x] get edit controls working
- [x] get adding a moderator by email working
- [x] fix row loading screen
- [x] move all text to translation file
- [x] update the error messages
- [x] add pagination controls
- [x] sort results alphabetically (backend)
- [x] fix linting errors
- [x] disable users in search results who are already moderators
- [x] disable everything for non-admin moderators
- [x] force refresh if a user is added or if pagination changes
- [x] add tests

## Purpose
Allow preprint providers to add and remove moderators using the moderation app.

## Depends on
* https://github.com/CenterForOpenScience/osf.io/pull/8186 (released)
* https://github.com/CenterForOpenScience/ember-osf/pull/370

## Changes
* Added "Moderators" tab
* Added "Moderators" link on dashboard
* Changed "Moderation" tab to "Submissions"
* Changed "Moderation" to "Submissions" on dashboard
* Made the tabs a little better shaped
* Added all of the moderator management functionality

![moderator-management](https://user-images.githubusercontent.com/7131985/40891470-2414c91c-6754-11e8-929f-ecc54f33f6c5.gif)

## Testing
Should look and act like [prototype](https://marvelapp.com/7hg387e/) with a few exceptions:
* When a new user is selected it keeps the input field
* Using header row instead of page title
* "Add new moderator" button is now just "Add"
* Moderators (as opposed to admin) cannot see the Permissions/Add/Remove functionality
* "Remove" instead of "Delete" moderators

Known oddities:
* You **can't add super users as moderators through the interface** (they have access though)
* We don't have a way of knowing the order that the users were added so alphabetical will have to do. This means that users added at the end might be in a different place if the page is reloaded.

## Ticket
https://openscience.atlassian.net/browse/IN-6