### PR TITLE
[IN-203][Reviews] Upgrade moment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- ember-cli-moment-shim version to `^3.5.3` due to security issues found in `moment` versions before `2.19.3`
 
 ## [0.4.1] - 2018-03-06
 ## Fixed
@@ -17,9 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Tests for provider setup controller
 
 ## Changed
-- Update language 
+- Update language
   - Add `Submitted by` along with the `accepted by/rejected by` for the accepted/rejected records in the moderation list
-  - Capitalize first letter (e.g `submitted by` to `Submitted by`) 
+  - Capitalize first letter (e.g `submitted by` to `Submitted by`)
 - Upgraded ember-cli to 2.16.2
 
 ## [0.3.1] - 2018-03-01
@@ -62,7 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use COS ember-base image and multi-stage build
   - Notify DevOps prior to merging into master to update Jenkins
 - Show moderator name (instead of creator) in the accepted/rejected records in the moderation list
-- Update style/layout for Reviews to be more mobile friendly 
+- Update style/layout for Reviews to be more mobile friendly
 
 ### Removed
 - Remove name link from action logs in the dashboard view

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-inline-content": "^0.4.1",
-    "ember-cli-moment-shim": "^3.4.0",
+    "ember-cli-moment-shim": "^3.5.3",
     "ember-cli-postcss": "^3.5.2",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-sass": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,20 +2865,20 @@ ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
 
-ember-cli-moment-shim@^3.4.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.5.0.tgz#7ea8d42b0a04c767258287b30447681e52fba0c4"
+ember-cli-moment-shim@^3.5.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.6.0.tgz#a6ce858e99b285eb9c539c8cebb698435f8d043a"
   dependencies:
     broccoli-funnel "^2.0.0"
     broccoli-merge-trees "^2.0.0"
     broccoli-source "^1.1.0"
     broccoli-stew "^1.5.0"
     chalk "^1.1.3"
-    ember-cli-babel "^6.8.2"
+    ember-cli-babel "^6.6.0"
     ember-cli-import-polyfill "^0.2.0"
     exists-sync "^0.0.4"
     lodash.defaults "^4.2.0"
-    moment "^2.18.1"
+    moment "^2.19.3"
     moment-timezone "^0.5.13"
 
 ember-cli-node-assets@^0.2.2:
@@ -6085,9 +6085,13 @@ moment-timezone@^0.5.13:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.18.1:
+"moment@>= 2.9.0":
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
+
+moment@^2.19.3:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 morgan@^1.8.1:
   version "1.9.0"


### PR DESCRIPTION
## Purpose

Fix security vulnerability: [CVE-2017-18214](https://nvd.nist.gov/vuln/detail/CVE-2017-18214)

## Summary of Changes

`yarn upgrade "ember-cli-moment-shim@^3.5.3"` which also upgrades moment to ^2.19.3

## Side Effects / Testing Notes

For reviews, please make sure the dates are formatted correctly as 'March 05, 2018' on
the provider moderation list say (reviews/preprints/bitss), dashboard, and on the preprint status banner.

## Ticket

[IN-203](https://openscience.atlassian.net/browse/IN-203)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`