### PR TITLE
[IN-311][Reviews] Remove bottom on alert maintenance banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent whitespace under banners
 
 ## [0.5.1] - 2018-04-24
 ### Changed

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -51,3 +51,8 @@ body > div.ember-view {
   margin: 0;
   padding: 0;
 }
+
+.alert-maintenance {
+  margin-top: 50px;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Purpose
Prevent space below banner.
<img width="1428" alt="screen shot 2018-05-22 at 5 13 34 pm" src="https://user-images.githubusercontent.com/7131985/40390688-064df8d2-5de4-11e8-9879-5ee321b2fc26.png">

## Changes
As done on [registries](https://github.com/CenterForOpenScience/ember-osf-registries/blob/0e6199bf2e3123788ab565f8b5d179f173c6a71d/app/styles/app.scss#L1172) and [preprints](https://github.com/CenterForOpenScience/ember-osf-preprints/blob/43af4d5acb05cb02b053e05424c5d8d8bc4b2f04/app/styles/app.scss#L1406), remove bottom margin on maintenance banner.

## Ticket
https://openscience.atlassian.net/browse/IN-311
