### PR TITLE
[IN-338][Reviews] GA anonymize sender ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.1] -
+### Added
+- `anonymizeIp: true` in GA config to anonymize sender IP.
 
 ## [0.6.0] - 2018-05-29
 ### Added
@@ -48,9 +50,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Tests for provider setup controller
 
 ### Changed
-- Update language 
+- Update language
   - Add `Submitted by` along with the `accepted by/rejected by` for the accepted/rejected records in the moderation list
-  - Capitalize first letter (e.g `submitted by` to `Submitted by`) 
+  - Capitalize first letter (e.g `submitted by` to `Submitted by`)
 - Upgraded ember-cli to 2.16.2
 
 ## [0.3.1] - 2018-03-01
@@ -93,7 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use COS ember-base image and multi-stage build
   - Notify DevOps prior to merging into master to update Jenkins
 - Show moderator name (instead of creator) in the accepted/rejected records in the moderation list
-- Update style/layout for Reviews to be more mobile friendly 
+- Update style/layout for Reviews to be more mobile friendly
 
 ### Removed
 - Remove name link from action logs in the dashboard view

--- a/config/environment.js
+++ b/config/environment.js
@@ -48,6 +48,10 @@ module.exports = function(environment) {
                     trace: environment === 'development',
                     // Ensure development env hits aren't sent to GA.
                     sendHitTask: environment !== 'development',
+                    setFields: {
+                        // Ensure the IP address of the sender will be anonymized.
+                        anonymizeIp: true,
+                    },
                 },
             },
         ],

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-font-awesome": "^3.0.0",
     "ember-i18n": "5.0.2",
     "ember-load-initializers": "^1.0.0",
+    "ember-metrics": "https://github.com/cos-forks/ember-metrics#v0.12.1+cos0",
     "ember-mockdate-shim": "^0.1.0",
     "ember-moment": "^7.4.1",
     "ember-onbeforeunload": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3556,9 +3556,9 @@ ember-maybe-import-regenerator@^0.1.5:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-metrics@^0.12.1:
+ember-metrics@^0.12.1, "ember-metrics@https://github.com/cos-forks/ember-metrics#v0.12.1+cos0":
   version "0.12.1"
-  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.12.1.tgz#8659343bf7b8bda403e70d482ff59cc9714d89f6"
+  resolved "https://github.com/cos-forks/ember-metrics#32fcc6eec0c4bc1974c854435401f94f660c6e74"
   dependencies:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"


### PR DESCRIPTION
## Purpose

as part of GDPR compliance efforts, `anonymizeIp: true` allows
the sender IPs to be anonymized.

## Summary of Changes

- Update config to set `anonymizeIp: true`
- Point to fork to allow setting GA configs.

## Side Effects / Testing Notes
In case GA is enabled on staging environments, you can verify this flag is set by looking at the GA requests in the console (filter by `collect`)

## Ticket

[IN-338](https://openscience.atlassian.net/browse/IN-338)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`
