### PR TITLE
[IN-327][Reviews] Add withdraw and view withdrawals features to reviews detail page and list page.

### DIFF
--- a/app/components/moderation-base/component.js
+++ b/app/components/moderation-base/component.js
@@ -17,14 +17,19 @@ export default Component.extend({
     store: service(),
 
     providerName: alias('theme.provider.name'),
-
-    tabs: computed('theme.reviewableStatusCounts.pending', function() {
+    tabs: computed('theme.reviewableStatusCounts.pending', 'theme.requestStatusCounts', function() {
         return [
             {
                 nameKey: 'global.submissions',
                 route: 'preprints.provider.moderation',
                 hasCount: true,
                 count: this.get('theme.reviewableStatusCounts.pending'),
+            },
+            {
+                nameKey: 'global.withdrawalRequests',
+                route: 'preprints.provider.withdrawals',
+                hasCount: true,
+                count: this.get('theme.requestStatusCounts.pending'),
             },
             {
                 nameKey: 'global.moderators',
@@ -40,4 +45,6 @@ export default Component.extend({
             },
         ];
     }),
+
+
 });

--- a/app/components/moderation-list/component.js
+++ b/app/components/moderation-list/component.js
@@ -30,23 +30,43 @@ export default Component.extend({
     classNames: ['content'],
 
     didReceiveAttrs() {
-        this.set('statusButtons', [
-            {
-                status: 'pending',
-                iconClass: 'fa-hourglass-o icon-pending',
-                labelKey: 'components.moderationList.pending',
-            },
-            {
-                status: 'accepted',
-                iconClass: 'fa-check-circle-o icon-accepted',
-                labelKey: 'components.moderationList.accepted',
-            },
-            {
-                status: 'rejected',
-                iconClass: 'fa-times-circle-o icon-rejected',
-                labelKey: 'components.moderationList.rejected',
-            },
-        ]);
+        if (this.get('isSubmissions')) {
+            this.set('statusButtons', [
+                {
+                    status: 'pending',
+                    iconClass: 'fa-hourglass-o icon-pending',
+                    labelKey: 'components.moderationList.pending',
+                },
+                {
+                    status: 'accepted',
+                    iconClass: 'fa-check-circle-o icon-accepted',
+                    labelKey: 'components.moderationList.accepted',
+                },
+                {
+                    status: 'rejected',
+                    iconClass: 'fa-times-circle-o icon-rejected',
+                    labelKey: 'components.moderationList.rejected',
+                },
+            ]);
+        } else if (this.get('isRequests')) {
+            this.set('statusButtons', [
+                {
+                    status: 'pending',
+                    iconClass: 'fa-hourglass-o icon-pending',
+                    labelKey: 'components.moderationList.pending',
+                },
+                {
+                    status: 'accepted',
+                    iconClass: 'fa-check-circle-o icon-accepted',
+                    labelKey: 'components.moderationList.approved',
+                },
+                {
+                    status: 'rejected',
+                    iconClass: 'fa-times-circle-o icon-rejected',
+                    labelKey: 'components.moderationList.declined',
+                },
+            ]);
+        }
 
         this.set('sortOptions', [
             {

--- a/app/components/moderation-list/template.hbs
+++ b/app/components/moderation-list/template.hbs
@@ -7,7 +7,12 @@
                         <button class="btn" local-class="reviews-btn-filter {{if (eq status statusButton.status) 'active-filter'}}"
                                 {{action statusChanged statusButton.status}}>
                             <i class="fa {{statusButton.iconClass}}"></i>
-                            <span>{{get theme.reviewableStatusCounts statusButton.status}}</span>
+                            {{#if isSubmissions}}
+                                <span>{{get theme.reviewableStatusCounts statusButton.status}}</span>
+                            {{/if}}
+                            {{#if isRequests}}
+                                <span>{{get theme.requestStatusCounts statusButton.status}}</span>
+                            {{/if}}
                             {{t statusButton.labelKey}}
                         </button>
                     {{/each}}
@@ -32,13 +37,29 @@
                     {{#if loading}}
                         {{moderation-list-row-skeleton}}
                     {{else}}
-                        {{#if (eq submissions.length 0)}}
+                        {{#if (and isSubmissions (eq submissions.length 0))}}
                             <div class="text-center p-v-md {{local-class 'moderation-list-row' from='reviews/components/moderation-list-row/styles'}}">
                                 {{t 'components.moderationList.noSubmissions'}}
                             </div>
                         {{else}}
                             {{#each submissions as |submission|}}
                                 {{moderation-list-row submission=submission}}
+                            {{/each}}
+                            <div class="pull-right text-right">
+                                {{pagination-pager
+                                    count=totalPages
+                                    current=page
+                                    change=(action pageChanged)
+                                }}
+                            </div>
+                        {{/if}}
+                        {{#if (and isRequests (eq requests.length 0))}}
+                            <div class="text-center p-v-md {{local-class 'moderation-list-row' from='reviews/components/moderation-list-row/styles'}}">
+                                {{t 'components.moderationList.noRequests'}}
+                            </div>
+                        {{else}}
+                            {{#each requests as |request|}}
+                                {{request-list-row request=request}}
                             {{/each}}
                             <div class="pull-right text-right">
                                 {{pagination-pager

--- a/app/components/preprint-status-banner/styles.scss
+++ b/app/components/preprint-status-banner/styles.scss
@@ -67,6 +67,16 @@
     }
 }
 
+.preprint-status-pending-withdrawal {
+    background-color: $color-state-warning-bg;
+    color: $color-state-warning-text;
+
+    .status-icon {
+        font-size: 16px;
+        -webkit-text-stroke: 0;
+    }
+}
+
 .status-badge {
     cursor: default;
     display: inline-block;  // required for the text-transform
@@ -117,6 +127,10 @@
         font-size: 1.4em;
     }
 
+    .withdrawal-justification {
+        font-size: 1.4em;
+    }
+
     .feedback-header {
         border-bottom: 1px solid $color-border;
         font-size: 2em;
@@ -161,7 +175,6 @@
 
         input {
             vertical-align: top;
-            width: 14px;  // prevents flex from making radio buttons smaller
         }
 
         p {

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -16,86 +16,141 @@
                 {{#if noActions}}
                     {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
                 {{else}}
-                    <a href={{creatorProfile}}>{{creatorName}}</a> {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
+                    {{#if isPendingWithdrawal}}
+                        <a href={{withdrawalRequesterProfile}}>{{withdrawalRequesterName}}</a> {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
+                    {{else}}
+                        <a href={{creatorProfile}}>{{creatorName}}</a> {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
+                    {{/if}}
                 {{/if}}
             {{/if}}
         </div>
         <div class="dropdown" local-class="reviewer-feedback">
-            {{#bs-dropdown closeOnMenuClick=false as |dd|}}
-                {{#dd.button type="success" disabled=submission.reviewActions.isPending}}
-                    {{#if submission.reviewActions.isPending}}
-                        <i local-class="button-loading-indicator" class="fa fa-circle-o-notch fa-spin"></i>
-                        {{t 'components.preprint-status-banner.loading'}}
-                    {{else}}
+            {{#if isPendingWithdrawal}}
+                {{! If there is a pending withdrawal request }}
+                {{#bs-dropdown closeOnMenuClick=false as |dd|}}
+                    {{#dd.button type="success" disabled=submission.reviewActions.isPending}}
                         {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
-                    {{/if}}
-                {{/dd.button}}
-                {{#dd.menu}}
-                    <div local-class="feedback-header">
-                        <span id="moderator-feedback">{{t labelDecisionHeader}}</span>
-                        {{#dd.toggle aria-label="Close" id="close"}}
-                            <i class="fa fa-times"></i>
-                        {{/dd.toggle}}
-                    </div>
-                    <div local-class="setting-reminder" class="p-md">
-                        <div class="p-b-sm row">
-                            <i class="fa {{settingsCommentsIcon}} fa-lg col-xs-1"></i>
-                            <span class="col-xs-11">{{t settingsComments}}</span>
+                    {{/dd.button}}
+                    {{#dd.menu}}
+                        <div local-class="feedback-header">
+                            <span id="moderator-feedback">{{t labelDecisionHeader}}</span>
+                            {{#dd.toggle aria-label="Close" id="close"}}
+                                <i class="fa fa-times"></i>
+                            {{/dd.toggle}}
                         </div>
-                        {{#if (not reviewsCommentsPrivate)}}
-                            <div class="p-b-sm row">
-                                <i class="fa {{settingsNamesIcon}} fa-lg col-xs-1"></i>
-                                <span class="col-xs-11">{{t settingsNames}}</span>
-                            </div>
+                        <div local-class="withdrawal-justification" class="p-md">
+                            <label>
+                                <span class="p-l-sm">
+                                    {{t 'components.preprintStatusBanner.withdrawalJustification'}}
+                                </span>
+                            </label>
+                            <p class="p-l-sm">
+                                {{ withdrawalRequest.comment }}
+                            </p>
+                        </div>
+                        <div local-class="moderator-decision" aria-labelledby="moderator-feedback">
+                            <form local-class="{{if noComment 'no-comment'}}">
+                                <label local-class="decision-option">
+                                    {{radio-button value="accepted" groupValue=decision changed="decisionToggled"}}
+                                    <span class="p-l-sm">
+                                    {{t labelApprove}}
+                                        <p>{{t approveExplanation}}</p>
+                                </span>
+                                </label>
+                                <label local-class="decision-option">
+                                    {{radio-button value="rejected" groupValue=decision changed="decisionToggled"}}
+                                    <span class="p-l-sm">
+                                    {{t labelDecline}}
+                                        <p>{{t declineExplanation}}</p>
+                                </span>
+                                </label>
+                            </form>
+                        </div>
+                        <div local-class="feedback-footer">
+                            <button class="btn btn-success pull-right" id="submit-btn" {{action "submit"}}>
+                                {{t labelDecisionBtn}}
+                            </button>
+                        </div>
+                    {{/dd.menu}}
+                {{/bs-dropdown}}
+            {{else}}
+                {{! If there is no pending withdrawal request }}
+                {{#bs-dropdown closeOnMenuClick=false as |dd|}}
+                    {{#dd.button type="success" disabled=submission.reviewActions.isPending}}
+                        {{#if submission.reviewActions.isPending}}
+                            <i local-class="button-loading-indicator" class="fa fa-circle-o-notch fa-spin"></i>
+                            {{t 'components.preprint-status-banner.loading'}}
+                        {{else}}
+                            {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
                         {{/if}}
-                        <div class="row">
-                            <i class="fa {{settingsModerationIcon}} fa-lg col-xs-1"></i>
-                            <span class="col-xs-11">{{t settingsModeration}}</span>
+                    {{/dd.button}}
+                    {{#dd.menu}}
+                        <div local-class="feedback-header">
+                            <span id="moderator-feedback">{{t labelDecisionHeader}}</span>
+                            {{#dd.toggle aria-label="Close" id="close"}}
+                                <i class="fa fa-times"></i>
+                            {{/dd.toggle}}
                         </div>
-                    </div>
-                    <div local-class="moderator-decision" aria-labelledby="moderator-feedback">
-                        <form local-class="{{if noComment 'no-comment'}}">
-                            <label local-class="decision-option">
-                                {{radio-button value="accepted" groupValue=decision changed="decisionToggled"}}
-                                <span class="p-l-sm">
-                                    {{t labelAccept}}
-                                    <p>{{t acceptExplanation}}</p>
-                                </span>
-                            </label>
-                            <label local-class="decision-option">
-                                {{radio-button value="rejected" groupValue=decision changed="decisionToggled"}}
-                                <span class="p-l-sm">
-                                    {{t labelReject}}
-                                    <p>{{t rejectExplanation}}</p>
-                                </span>
-                            </label>
-                            {{textarea
-                                key-up=(action "commentChanged")
-                                value=reviewerComment
-                                rows="8" placeholder=(t commentPlaceholder)
-                                class="form-control"
-                            }}
-                            {{#if commentExceedsLimit}}
-                                <div local-class="comment-length-error">
-                                    {{commentLengthErrorMessage}}
+                        <div local-class="setting-reminder" class="p-md">
+                            <div class="p-b-sm row">
+                                <i class="fa {{settingsCommentsIcon}} fa-lg col-xs-1"></i>
+                                <span class="col-xs-11">{{t settingsComments}}</span>
+                            </div>
+                            {{#if (not reviewsCommentsPrivate)}}
+                                <div class="p-b-sm row">
+                                    <i class="fa {{settingsNamesIcon}} fa-lg col-xs-1"></i>
+                                    <span class="col-xs-11">{{t settingsNames}}</span>
                                 </div>
                             {{/if}}
-                        </form>
-                    </div>
-                    <div local-class="feedback-footer">
-                        <button class="btn btn-success pull-right" id="submit-btn" disabled={{btnDisabled}} {{action "submit"}}>
-                            {{t labelDecisionBtn}}
-                        </button>
-                        {{#if (not-eq submission.reviewsState 'pending')}}
-                            {{#dd.toggle}}
-                                <button class="btn btn-default pull-right" {{action "cancel"}}>
-                                    {{t "global.cancel"}}
-                                </button>
-                            {{/dd.toggle}}
-                        {{/if}}
-                    </div>
-                {{/dd.menu}}
-            {{/bs-dropdown}}
+                            <div class="row">
+                                <i class="fa {{settingsModerationIcon}} fa-lg col-xs-1"></i>
+                                <span class="col-xs-11">{{t settingsModeration}}</span>
+                            </div>
+                        </div>
+                        <div local-class="moderator-decision" aria-labelledby="moderator-feedback">
+                            <form local-class="{{if noComment 'no-comment'}}">
+                                <label local-class="decision-option">
+                                    {{radio-button value="accepted" groupValue=decision changed="decisionToggled"}}
+                                    <span class="p-l-sm">
+                                    {{t labelAccept}}
+                                        <p>{{t acceptExplanation}}</p>
+                                </span>
+                                </label>
+                                <label local-class="decision-option">
+                                    {{radio-button value="rejected" groupValue=decision changed="decisionToggled"}}
+                                    <span class="p-l-sm">
+                                    {{t labelReject}}
+                                        <p>{{t rejectExplanation}}</p>
+                                </span>
+                                </label>
+                                {{textarea
+                                    key-up=(action "commentChanged")
+                                    value=reviewerComment
+                                    rows="8" placeholder=(t commentPlaceholder)
+                                    class="form-control"
+                                }}
+                                {{#if commentExceedsLimit}}
+                                    <div local-class="comment-length-error">
+                                        {{commentLengthErrorMessage}}
+                                    </div>
+                                {{/if}}
+                            </form>
+                        </div>
+                        <div local-class="feedback-footer">
+                            <button class="btn btn-success pull-right" id="submit-btn" disabled={{btnDisabled}} {{action "submit"}}>
+                                {{t labelDecisionBtn}}
+                            </button>
+                            {{#if (not-eq submission.reviewsState 'pending')}}
+                                {{#dd.toggle}}
+                                    <button class="btn btn-default pull-right" {{action "cancel"}}>
+                                        {{t "global.cancel"}}
+                                    </button>
+                                {{/dd.toggle}}
+                            {{/if}}
+                        </div>
+                    {{/dd.menu}}
+                {{/bs-dropdown}}
+            {{/if}}
         </div>
     </div>
 </div>

--- a/app/components/request-list-row/component.js
+++ b/app/components/request-list-row/component.js
@@ -1,0 +1,78 @@
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+
+import moment from 'moment';
+import { task } from 'ember-concurrency';
+
+import latestAction from 'reviews/utils/latest-action';
+
+const ACCEPTED = 'accepted';
+const REJECTED = 'rejected';
+
+const submittedOnLabel = {
+    gtDay: 'components.requestListRow.submission.requestedOn',
+    ltDay: 'components.requestListRow.submission.requested',
+};
+
+const ACTION_LABELS = Object.freeze({
+    [ACCEPTED]: {
+        gtDay: 'components.requestListRow.submission.approvedOn',
+        ltDay: 'components.requestListRow.submission.approved',
+    },
+    [REJECTED]: {
+        gtDay: 'components.requestListRow.submission.declinedOn',
+        ltDay: 'components.requestListRow.submission.declined',
+    },
+});
+
+
+export default Component.extend({
+    theme: service(),
+    i18n: service(),
+
+    localClassNames: ['moderation-list-row'],
+
+    isWithdrawn: computed('request.machineState', function() {
+        return this.get('request.machineState') === 'accepted';
+    }),
+
+    latestAction: computed('request.target.reviewActions.[]', function() {
+        return latestAction(this.get('request.target.reviewActions'));
+    }),
+
+    latestActionCreator: computed.alias('latestAction.creator.fullName'),
+
+    decisionOnLabel: computed('request.machineState', 'request.dateLastTransitioned', 'latestActionCreator', function() {
+        const i18n = this.get('i18n');
+        const [acceptedRejectedDate, gtDay] = this.formattedDateLabel(this.get('request.dateLastTransitioned'));
+        const dayValue = gtDay ? 'gtDay' : 'ltDay';
+        const status = this.get('request.machineState');
+        const labels = ACTION_LABELS[status][dayValue];
+        return i18n.t(labels, { timeDate: acceptedRejectedDate, moderatorName: this.get('latestActionCreator') });
+    }),
+
+    requestedOnLabel: computed('request.created', 'request.creator.fullnName', function() {
+        const i18n = this.get('i18n');
+        const [submitDate, gtDaySubmit] = this.formattedDateLabel(this.get('request.created'));
+        const dayValue = gtDaySubmit ? 'gtDay' : 'ltDay';
+        const labels = submittedOnLabel[dayValue];
+        return i18n.t(labels, { timeDate: submitDate, submitterName: this.get('request.creator.fullName')});
+    }),
+
+    didReceiveAttrs() {
+        this.iconClass = {
+            accepted: 'fa-check-circle-o accepted',
+            pending: 'fa-hourglass-o pending',
+            rejected: 'fa-times-circle-o rejected',
+        };
+    },
+
+    formattedDateLabel(rawDate) {
+        const gtDayAgo = moment().diff(rawDate, 'days') > 1;
+        const formattedDate = gtDayAgo ?
+            moment(rawDate).format('MMMM DD, YYYY') :
+            moment(Math.min(Date.parse(rawDate), Date.now())).fromNow();
+        return [formattedDate, gtDayAgo];
+    },
+});

--- a/app/components/request-list-row/styles.scss
+++ b/app/components/request-list-row/styles.scss
@@ -1,0 +1,90 @@
+.flex-container {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+}
+
+.status-icon {
+    padding-left: 20px;
+
+    @media screen and (max-width: $screen-small-tablet) {
+        font-size: 16px;
+    }
+}
+
+.pending {
+    color: $color-action-submit;
+}
+
+.rejected {
+    color: $color-action-reject;
+}
+
+.accepted {
+    color: $color-action-accept;
+}
+
+.submission-info {
+    padding: 10px 20px;
+    color: $color-text-gray-dark;
+    min-width: 0;  // needed for the text-overflow on submission-title
+}
+
+.submission-title {
+    font-size: 20px;
+    font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    @media screen and (max-width: $screen-small-tablet) {
+        font-size: 14px;
+    }
+}
+
+.submission-body {
+    font-size: 16px;
+
+    li {
+        display: inline;
+    }
+
+    li::after {
+        content: ', ';
+    }
+
+    li:last-child::after {
+        content: '';
+    }
+
+    @media screen and (max-width: $screen-small-tablet) {
+        font-size: 12px;
+    }
+
+}
+
+a:link {
+    text-decoration: none;
+}
+
+a:visited {
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: none;
+}
+
+a:active {
+    text-decoration: none;
+}
+
+
+.moderation-list-row {
+    border: 1px solid $color-border;
+}
+
+.moderation-list-row:hover {
+    background-color: $color-bg-gray-light;
+}

--- a/app/components/request-list-row/template.hbs
+++ b/app/components/request-list-row/template.hbs
@@ -1,0 +1,21 @@
+{{#if fetchData.isRunning}}
+    {{moderation-list-row-skeleton}}
+{{else}}
+    {{#link-to 'preprints.provider.preprint-detail' theme.id request.target.id}}
+        <div data-status={{request.target.reviewsState}} local-class="flex-container">
+            <i class="fa fa-lg {{get iconClass request.machineState}}" local-class="{{get iconClass request.machineState}} status-icon"></i>
+            <div title={{request.target.title}} local-class="submission-info">
+                <div local-class="submission-title">{{request.target.title}}</div>
+                <div local-class="submission-body">
+                    {{#if isWithdrawn}}
+                        <div>{{decisionOnLabel}}</div>
+                    {{else}}
+                        <div>
+                            {{requestedOnLabel}}
+                        </div>
+                    {{/if}}
+                </div>
+            </div>
+        </div>
+    {{/link-to}}
+{{/if}}

--- a/app/components/request-list-row/template.hbs
+++ b/app/components/request-list-row/template.hbs
@@ -1,7 +1,7 @@
 {{#if fetchData.isRunning}}
     {{moderation-list-row-skeleton}}
 {{else}}
-    {{#link-to 'preprints.provider.preprint-detail' theme.id request.target.id}}
+    {{#link-to 'preprints.provider.preprint-detail-withdrawal' theme.id request.target.id}}
         <div data-status={{request.target.reviewsState}} local-class="flex-container">
             <i class="fa fa-lg {{get iconClass request.machineState}}" local-class="{{get iconClass request.machineState}} status-icon"></i>
             <div title={{request.target.title}} local-class="submission-info">

--- a/app/controllers/preprints/provider/moderation.js
+++ b/app/controllers/preprints/provider/moderation.js
@@ -47,6 +47,7 @@ export default Controller.extend(Analytics, moderationQueryParams.Mixin, {
     },
 
     setup({ queryParams }) {
+        console.log('fetching reviews');
         this.get('fetchData').perform(queryParams);
     },
 

--- a/app/controllers/preprints/provider/withdrawals.js
+++ b/app/controllers/preprints/provider/withdrawals.js
@@ -41,6 +41,7 @@ export default Controller.extend(Analytics, moderationQueryParams.Mixin, {
     },
 
     setup({ queryParams }) {
+        console.log('fetching requests');
         this.get('fetchData').perform(queryParams);
     },
 

--- a/app/controllers/preprints/provider/withdrawals.js
+++ b/app/controllers/preprints/provider/withdrawals.js
@@ -1,0 +1,81 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+import QueryParams from 'ember-parachute';
+import { task } from 'ember-concurrency';
+
+import Analytics from 'ember-osf/mixins/analytics';
+
+
+export const moderationQueryParams = new QueryParams({
+    page: {
+        defaultValue: 1,
+        refresh: true,
+    },
+    sort: {
+        defaultValue: '-date_last_transitioned',
+        refresh: true,
+    },
+    status: {
+        defaultValue: 'pending',
+        refresh: true,
+    },
+});
+
+export default Controller.extend(Analytics, moderationQueryParams.Mixin, {
+    store: service(),
+    theme: service(),
+
+    actions: {
+        statusChanged(status) {
+            this.resetQueryParams(['page']);
+            this.set('status', status);
+        },
+        pageChanged(page) {
+            this.set('page', page);
+        },
+        sortChanged(sort) {
+            this.resetQueryParams(['page']);
+            this.set('sort', sort);
+        },
+    },
+
+    setup({ queryParams }) {
+        this.get('fetchData').perform(queryParams);
+    },
+
+    queryParamsDidChange({ shouldRefresh, queryParams }) {
+        if (shouldRefresh) {
+            this.get('fetchData').perform(queryParams);
+        }
+    },
+
+    reset(isExiting) {
+        if (isExiting) {
+            this.resetQueryParams();
+        }
+    },
+
+    fetchData: task(function* (queryParams) {
+        console.log('fetching data');
+        const providerId = this.get('theme.provider.id');
+        const response = yield this.get('store').query(
+            'preprint-request',
+            {
+                providerId: this.get('theme').provider.id,
+                filter: {
+                    machine_state: queryParams.status,
+                },
+                'meta[requests_state_counts]': true,
+                embed: 'target',
+                sort: queryParams.sort,
+                page: queryParams.page,
+            },
+        );
+        this.get('theme').set('requestStatusCounts', response.meta.requests_state_counts);
+        this.set('results', {
+            requests: response.toArray(),
+            totalPages: Math.ceil(response.meta.total / response.meta.per_page),
+        });
+    }),
+});

--- a/app/controllers/preprints/provider/withdrawals.js
+++ b/app/controllers/preprints/provider/withdrawals.js
@@ -57,7 +57,6 @@ export default Controller.extend(Analytics, moderationQueryParams.Mixin, {
     },
 
     fetchData: task(function* (queryParams) {
-        console.log('fetching data');
         const providerId = this.get('theme.provider.id');
         const response = yield this.get('store').query(
             'preprint-request',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -242,6 +242,7 @@ export default {
                 pending: 'submitted this {{documentType.singular}} on',
                 accepted: 'accepted this {{documentType.singular}} on',
                 rejected: 'rejected this {{documentType.singular}} on',
+                pendingWithdrawal: 'requested to withdraw this {{documentType.singular}} on',
                 automatic: {
                     pending: 'This {{documentType.singular}} was submitted on',
                     accepted: 'This {{documentType.singular}} was automatically accepted on',
@@ -252,7 +253,9 @@ export default {
                 pendingPost: 'publicly available and searchable but is subject to removal by a moderator',
                 accepted: 'publicly available and searchable',
                 rejected: 'not publicly available or searchable',
+                pendingWithdrawal: 'not public available or searchable once the withdrawal request is approved'
             },
+            withdrawalJustification: 'Reason for withdrawal',
             pending: 'pending',
             accepted: 'accepted',
             rejected: 'rejected',
@@ -282,6 +285,14 @@ export default {
                     label: 'Reject',
                     pre: 'Submission will not appear in search results and will remain private.',
                     post: 'Submission will be removed from search results and made private.',
+                },
+                approve: {
+                    label: 'Approve',
+                    explanation: 'Submission will be withdrawn but still have a tombstone page with a subset of the metadata available',
+                },
+                decline: {
+                    label: 'Decline',
+                    explanation: 'Submission will remain fully public',
                 },
             },
             settings: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -228,6 +228,8 @@ export default {
                 requested: 'Requested {{timeDate}} by {{submitterName}}',
                 approvedOn: 'Approved on {{timeDate}} by {{moderatorName}}',
                 approved: 'Approved {{timeDate}} by {{moderatorName}}',
+                approvedAutomaticallyOn: 'Approved automatically on {{timeDate}}',
+                approvedAutomatically: 'Approved automatically {{timeDate}}',
                 declinedOn: 'Declined on {{timeDate}} by {{moderatorName}}',
                 declined: 'Declined {{timeDate}} by {{moderatorName}}',
             },

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -17,6 +17,7 @@ export default {
         notifications: 'Notifications',
         submissions: 'Submissions',
         moderators: 'Moderators',
+        withdrawalRequests: 'Withdrawal Requests',
     },
     index: {
         feature: {
@@ -203,8 +204,11 @@ export default {
             pending: 'Pending',
             accepted: 'Accepted',
             rejected: 'Rejected',
+            approved: 'Approved',
+            declined: 'Declined',
             sort: 'Sort',
             noSubmissions: 'No submissions.',
+            noRequests: 'No requests.',
         },
         moderationListRow: {
             submission: {
@@ -216,6 +220,16 @@ export default {
                 acceptedAutomatically: 'Accepted automatically {{timeDate}}',
                 rejectedOn: 'Rejected on {{timeDate}} by {{moderatorName}}',
                 rejected: 'Rejected {{timeDate}} by {{moderatorName}}',
+            },
+        },
+        requestListRow: {
+            submission: {
+                requestedOn: 'Requested on {{timeDate}} by {{submitterName}}',
+                requested: 'Requested {{timeDate}} by {{submitterName}}',
+                approvedOn: 'Approved on {{timeDate}} by {{moderatorName}}',
+                approved: 'Approved {{timeDate}} by {{moderatorName}}',
+                declinedOn: 'Declined on {{timeDate}} by {{moderatorName}}',
+                declined: 'Declined {{timeDate}} by {{moderatorName}}',
             },
         },
         notificationList: {

--- a/app/router.js
+++ b/app/router.js
@@ -81,6 +81,7 @@ Router.map(function() {
             this.route('settings');
             this.route('preprint-detail', { path: ':preprint_id' });
             this.route('notifications');
+            this.route('withdrawals');
         });
     });
     this.route('dashboard');

--- a/app/router.js
+++ b/app/router.js
@@ -80,6 +80,7 @@ Router.map(function() {
             this.route('moderators');
             this.route('settings');
             this.route('preprint-detail', { path: ':preprint_id' });
+            this.route('preprint-detail-withdrawal', { path: ':preprint_id/withdrawal' });
             this.route('notifications');
             this.route('withdrawals');
         });

--- a/app/routes/preprints/provider/preprint-detail-withdrawal.js
+++ b/app/routes/preprints/provider/preprint-detail-withdrawal.js
@@ -1,0 +1,19 @@
+import PreprintDetail from '../provider/preprint-detail'
+
+export default PreprintDetail.extend({
+    setupController(controller, model) {
+        let detailController = this.controllerFor('preprints.provider.preprint-detail');
+        detailController.set('isPendingWithdrawal', false);
+        detailController.get('fetchData').perform(model.preprintId, true);
+    },
+    renderTemplate(controller, model) {
+        // We're a special page.
+        // Render into the applications outlet rather than the `provider` outlet.
+        let detailController = this.controllerFor('preprints.provider.preprint-detail');
+        this.render('preprints.provider.preprint-detail', {
+            detailController,
+            into: 'application',
+            model,
+        });
+    },
+});

--- a/app/routes/preprints/provider/preprint-detail.js
+++ b/app/routes/preprints/provider/preprint-detail.js
@@ -13,6 +13,7 @@ export default Route.extend(ConfirmationMixin, {
 
     setupController(controller, model) {
         this._super(...arguments);
+        controller.set('isPendingWithdrawal', false);
         controller.get('fetchData').perform(model.preprintId);
     },
 

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -12,6 +12,7 @@ export default Service.extend({
 
     provider: null,
     reviewableStatusCounts: null,
+    request: null,
 
     id: alias('provider.id'),
     domain: alias('provider.domain'),
@@ -57,6 +58,14 @@ export default Service.extend({
     _onProviderLoad(provider) {
         this.set('provider', provider);
         this.set('reviewableStatusCounts', provider.get('reviewableStatusCounts'));
+        this.get('store').query(
+            'preprint-request',
+            {
+                providerId: provider.id,
+                'meta[requests_state_counts]': true,
+            },
+        ).then(this._setRequestStatusCounts.bind(this));
+
         this.get('i18n').addGlobals({
             provider: {
                 id: this.get('provider.id'),
@@ -65,4 +74,8 @@ export default Service.extend({
         });
         return provider;
     },
+
+    _setRequestStatusCounts(response) {
+        this.set('requestStatusCounts', response.meta.requests_state_counts)
+    }
 });

--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -20,7 +20,7 @@
         {{#if (or fetchData.isRunning (not preprint))}}
             <div local-class="preprint-status-component--skeleton"></div>
         {{else}}
-            {{preprint-status-banner submission=preprint saving=savingAction setUserEnteredReview=(action (mut userHasEnteredReview)) submitDecision=(action 'submitDecision')}}
+            {{preprint-status-banner submission=preprint withdrawalRequest=withdrawalRequest isPendingWithdrawal=isPendingWithdrawal saving=savingAction setUserEnteredReview=(action (mut userHasEnteredReview)) submitDecision=(action 'submitDecision')}}
         {{/if}}
     </div>
 

--- a/app/templates/preprints/provider/withdrawals.hbs
+++ b/app/templates/preprints/provider/withdrawals.hbs
@@ -2,8 +2,8 @@
     statusChanged=(action 'statusChanged')
     pageChanged=(action 'pageChanged')
     sortChanged=(action 'sortChanged')
-    submissions=results.submissions
-    isSubmissions=true
+    requests=results.requests
+    isRequests=true
     page=page
     sort=sort
     status=status


### PR DESCRIPTION
## Purpose

This PR adds two things:
- The functionality of approving withdrawal requests from the reviews preprint detail page.
- The `withdrawal requests` tab on the reviews moderation page.

## Summary of Changes/Side Effects

Um... There's a lot. Let me think about this a bit...

## Testing Notes



## Ticket

https://openscience.atlassian.net/browse/IN-327

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
