### PR TITLE
[IN-346][Reviews] Show preprintDoiUrl if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Use `name` field for contributors on preprint-detail page
 - Prevent banner from loading on `preprint-detail` page if preprint is undefined
+- Show DOI url if it exists
 
 ## Changed
 - Use Ember-CSS-Modules

--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -92,7 +92,7 @@
 
                         <section class="p-t-xs">
                             <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI"}}</strong></h4>
-                            {{#if preprint.isPublished}}
+                            {{#if preprint.preprintDoiUrl}}
                                 {{#if preprint.preprintDoiCreated}}
                                     <a href={{preprint.preprintDoiUrl}}>{{extract-doi preprint.preprintDoiUrl}}</a>
                                 {{else}}


### PR DESCRIPTION
## Purpose
Fix `preprintDoiUrl` display logic.

## Summary of Changes/Side Effects
* If the url is there, show it
* If not, and it's published, show the "being minted" language
* Otherwise, show the "publish this to make a DOI" language

## Testing Notes
Ticket details steps to reproduce

## Ticket
[[IN-346]](https://openscience.atlassian.net/browse/IN-346)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`
