### PR TITLE
[No-ticket][Reviews] Add ember-cli-boostrap-sassy back

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-cli": "2.16.2",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-babel": "^6.3.0",
+    "ember-cli-bootstrap-sassy": "^0.5.8",
     "ember-cli-code-coverage": "^0.4.2",
     "ember-cli-dependency-checker": "^2.0.1",
     "ember-cli-eslint": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,7 +1377,7 @@ bootstrap-datepicker@^1.6.4:
   dependencies:
     jquery ">=1.7.1 <4.0.0"
 
-bootstrap-sass@^3.3.7:
+bootstrap-sass@^3.0.0, bootstrap-sass@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
@@ -3000,6 +3000,17 @@ ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.9.2:
     clone "^2.0.0"
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
+
+ember-cli-bootstrap-sassy@^0.5.8:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/ember-cli-bootstrap-sassy/-/ember-cli-bootstrap-sassy-0.5.8.tgz#9bb6d4c3f7f8a634fc51b0f2a29983d82e88b404"
+  dependencies:
+    bootstrap-sass "^3.0.0"
+    broccoli-funnel "^1.2.0"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-stew "^1.5.0"
+    ember-cli-babel "^6.6.0"
+    resolve "^1.1.7"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
Removing this package caused navbar dropdowns to be unclickable

<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
<!-- Why is this change necessary? What does it do? -->


## Summary of Changes/Side Effects
<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->


## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->


## Ticket

https://openscience.atlassian.net/browse/IN-

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
