### PR TITLE
[Preprint Withdrawals][Reviews][EMB-548][EMB-551] Preprint Withdrawal for Reviews.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.7.0] - 2018-09-04
 ### Added
 - Custom dimensions to `trackPage` for Google Analytics
+- Tombstone for withdrawn preprints
+- Withdrawn section to moderation list
+- Ability to withdraw from `preprint-detail` page
 
 ### Fixed
 - Use `name` field for contributors on preprint-detail page

--- a/app/components/action-feed-entry/component.js
+++ b/app/components/action-feed-entry/component.js
@@ -6,11 +6,13 @@ const SUBMIT = 'submit';
 const ACCEPT = 'accept';
 const REJECT = 'reject';
 const EDIT_COMMENT = 'edit_comment';
+const WITHDRAW = 'withdraw';
 
 const ICONS = Object.freeze({
     [SUBMIT]: 'fa-hourglass-o',
     [ACCEPT]: 'fa-check-circle-o',
     [REJECT]: 'fa-times-circle-o',
+    [WITHDRAW]: 'fa-times-circle-o',
     [EDIT_COMMENT]: 'fa-comment-o',
 });
 
@@ -19,6 +21,7 @@ const CLASS_NAMES = Object.freeze({
     [ACCEPT]: 'accept-icon',
     [REJECT]: 'reject-icon',
     [EDIT_COMMENT]: 'edit-comment-icon',
+    [WITHDRAW]: 'reject-icon',
 });
 
 /**

--- a/app/components/moderation-base/component.js
+++ b/app/components/moderation-base/component.js
@@ -17,14 +17,19 @@ export default Component.extend({
     store: service(),
 
     providerName: alias('theme.provider.name'),
-
-    tabs: computed('theme.reviewableStatusCounts.pending', function() {
+    tabs: computed('theme.{reviewableStatusCounts.pending,requestStatusCounts.pending}', function() {
         return [
             {
                 nameKey: 'global.submissions',
                 route: 'preprints.provider.moderation',
                 hasCount: true,
                 count: this.get('theme.reviewableStatusCounts.pending'),
+            },
+            {
+                nameKey: 'global.withdrawalRequests',
+                route: 'preprints.provider.withdrawals',
+                hasCount: true,
+                count: this.get('theme.requestStatusCounts.pending'),
             },
             {
                 nameKey: 'global.moderators',
@@ -40,4 +45,5 @@ export default Component.extend({
             },
         ];
     }),
+
 });

--- a/app/components/moderation-list-row/component.js
+++ b/app/components/moderation-list-row/component.js
@@ -15,6 +15,11 @@ const submittedOnLabel = {
     ltDay: 'components.moderationListRow.submission.submitted',
 };
 
+const withdrawnOnLabel = {
+    gtDay: 'components.moderationListRow.submission.withdrawnOn',
+    ltDay: 'components.moderationListRow.submission.withdrawn',
+};
+
 const ACTION_LABELS = Object.freeze({
     [ACCEPTED]: {
         gtDay: 'components.moderationListRow.submission.acceptedOn',
@@ -74,11 +79,25 @@ export default Component.extend({
         return i18n.t(labels, { timeDate: submitDate });
     }),
 
+    // translations for withdrawn on label
+    withdrawnOnLabel: computed('submission.dateWithdrawn', function() {
+        const i18n = this.get('i18n');
+        const [withdrawnDate, gtDayWithdrawn] = this.formattedDateLabel(this.get('submission.dateWithdrawn'));
+        const dayValue = gtDayWithdrawn ? 'gtDay' : 'ltDay';
+        const labels = withdrawnOnLabel[dayValue];
+        return i18n.t(labels, { timeDate: withdrawnDate, moderatorName: this.get('latestActionCreator') });
+    }),
+
+    icon: computed('submission.reviewsState', function() {
+        return this.get(`iconClass.${this.get('submission.reviewsState')}`);
+    }),
+
     didReceiveAttrs() {
         this.iconClass = {
-            accepted: 'fa-check-circle-o accepted',
-            pending: 'fa-hourglass-o pending',
-            rejected: 'fa-times-circle-o rejected',
+            accepted: ['fa-check-circle-o accepted'],
+            pending: ['fa-hourglass-o pending'],
+            rejected: ['fa-times-circle-o rejected'],
+            withdrawn: ['fa-circle-o rejected', 'fa-minus rejected'],
         };
         this.get('fetchData').perform();
     },

--- a/app/components/moderation-list-row/template.hbs
+++ b/app/components/moderation-list-row/template.hbs
@@ -3,20 +3,28 @@
 {{else}}
     {{#link-to 'preprints.provider.preprint-detail' theme.id submission.id}}
         <div data-status={{submission.reviewsState}} local-class="flex-container">
-            <i class="fa fa-lg {{get iconClass submission.reviewsState}}" local-class="{{get iconClass submission.reviewsState}} status-icon"></i>
+            <span class="fa-stack">
+                {{#each icon as |class|}}
+                    <i class="fa fa-lg {{class}} fa-stack-1x" local-class="{{submission.reviewsState}} status-icon"></i>
+                {{/each}}
+            </span>
             <div title={{submission.title}} local-class="submission-info">
                 <div local-class="submission-title">{{submission.title}}</div>
                 <div local-class="submission-body">
                     <div>
-                        {{submittedOnLabel}}
-                        {{#each firstContributors as |contributor| ~}}
-                            <li>{{contributor.users.fullName}}</li>
-                        {{/each}}
-                        {{#if (gt additionalContributors 0)}}
-                            + {{additionalContributors}}
+                        {{#if (not-eq submission.reviewsState 'withdrawn')}}
+                            {{submittedOnLabel}}
+                            {{#each firstContributors as |contributor| ~}}
+                                <li>{{contributor.users.fullName}}</li>
+                            {{/each}}
+                            {{#if (gt additionalContributors 0)}}
+                                + {{additionalContributors}}
+                            {{/if}}
+                        {{else}}
+                            {{withdrawnOnLabel}}
                         {{/if}}
                     </div>
-                    {{#if (not-eq submission.reviewsState 'pending')}}
+                    {{#if (and (not-eq submission.reviewsState 'pending') (not-eq submission.reviewsState 'withdrawn'))}}
                         <div>{{reviewedOnLabel}}</div>
                     {{/if}}
                 </div>

--- a/app/components/moderation-list/component.js
+++ b/app/components/moderation-list/component.js
@@ -30,24 +30,48 @@ export default Component.extend({
     classNames: ['content'],
 
     didReceiveAttrs() {
-        this.set('statusButtons', [
-            {
-                status: 'pending',
-                iconClass: 'fa-hourglass-o icon-pending',
-                labelKey: 'components.moderationList.pending',
-            },
-            {
-                status: 'accepted',
-                iconClass: 'fa-check-circle-o icon-accepted',
-                labelKey: 'components.moderationList.accepted',
-            },
-            {
-                status: 'rejected',
-                iconClass: 'fa-times-circle-o icon-rejected',
-                labelKey: 'components.moderationList.rejected',
-            },
-        ]);
-
+        if (this.get('isSubmissions')) {
+            this.set('statusButtons', [
+                {
+                    status: 'pending',
+                    iconClass: ['fa-hourglass-o icon-pending'],
+                    labelKey: 'components.moderationList.pending',
+                },
+                {
+                    status: 'accepted',
+                    iconClass: ['fa-check-circle-o icon-accepted'],
+                    labelKey: 'components.moderationList.accepted',
+                },
+                {
+                    status: 'rejected',
+                    iconClass: ['fa-times-circle-o icon-rejected'],
+                    labelKey: 'components.moderationList.rejected',
+                },
+                {
+                    status: 'withdrawn',
+                    iconClass: ['fa-circle-o icon-accepted', 'fa-minus icon-withdrawn'],
+                    labelKey: 'components.moderationList.withdrawn',
+                },
+            ]);
+        } else if (this.get('isRequests')) {
+            this.set('statusButtons', [
+                {
+                    status: 'pending',
+                    iconClass: ['fa-hourglass-o icon-pending'],
+                    labelKey: 'components.moderationList.pending',
+                },
+                {
+                    status: 'accepted',
+                    iconClass: ['fa-check-circle-o icon-accepted'],
+                    labelKey: 'components.moderationList.approved',
+                },
+                {
+                    status: 'rejected',
+                    iconClass: ['fa-times-circle-o icon-rejected'],
+                    labelKey: 'components.moderationList.declined',
+                },
+            ]);
+        }
         this.set('sortOptions', [
             {
                 sort: '-date_last_transitioned',

--- a/app/components/moderation-list/styles.scss
+++ b/app/components/moderation-list/styles.scss
@@ -7,15 +7,15 @@
         outline: none;
         padding: 6px 0;
 
-        @media screen and (max-width: $screen-small-tablet) {
+        @media screen and (max-width: 731px) {
             font-size: 16px;
         }
 
-        @media screen and (max-width: $screen-medium-small) {
+        @media screen and (max-width: 543px) {
             font-size: 14px;
         }
 
-        @media screen and (max-width: $screen-xs) {
+        @media screen and (max-width: 488px) {
             display: block;
         }
     }
@@ -35,7 +35,7 @@
     border: 1px solid $color-border;
     padding: 10px 20px;
 
-    @media screen and (max-width: $screen-small-tablet) {
+    @media screen and (max-width: 731px) {
         .moderation-list-heading {
             padding-left: 20px;
         }
@@ -48,12 +48,32 @@
     :global(.icon-rejected) {
         -webkit-text-stroke: 1px $color-bg-gray-light;
     }
+    
+    :global(.icon-withdrawn) {
+        -webkit-text-stroke: 1px $color-bg-gray-light;
+    }
+
+    :global(.fa-stack) {
+        line-height: 0.8em;
+        height: 1em;
+        width: 1em;
+    }
+
+    :global(.fa-minus) {
+        font-size: 14px;
+        line-height: 1.25em;
+
+        @media screen and (max-width: 731px) {
+            font-size: 10px;
+            line-height: inherit;
+        }
+    }
 
     :global(.dropdown-toggle) {
         color: $color-text-gray-dark;
         text-decoration: none;
 
-        @media screen and (max-width: $screen-xs) {
+        @media screen and (max-width: 488px) {
             margin-top: -2.3em;
         }
     }
@@ -61,7 +81,7 @@
     :global(.dropdown-menu) {
         background: $color-bg-gray-light;
 
-        @media screen and (max-width: $screen-xs) {
+        @media screen and (max-width: 488px) {
             margin-top: -0.7em;
         }
 
@@ -88,7 +108,7 @@
     margin: 0;
     margin-right: 20px;
 
-    @media screen and (max-width: $screen-small-tablet) {
+    @media screen and (max-width: 731px) {
         margin-right: 1px;
     }
 }

--- a/app/components/moderation-list/template.hbs
+++ b/app/components/moderation-list/template.hbs
@@ -5,9 +5,23 @@
                 <div local-class="reviews-list-heading">
                     {{#each statusButtons as |statusButton|}}
                         <button class="btn" local-class="reviews-btn-filter {{if (eq status statusButton.status) 'active-filter'}}"
-                                {{action statusChanged statusButton.status}}>
-                            <i class="fa {{statusButton.iconClass}}"></i>
-                            <span>{{get theme.reviewableStatusCounts statusButton.status}}</span>
+                            {{action statusChanged statusButton.status}}>
+                            {{#if isSubmissions}}
+                                <span class="fa-stack">
+                                    {{#each statusButton.iconClass as |class|}}
+                                        <i class="fa {{class}} fa-stack-1x"></i>
+                                    {{/each}}
+                                </span>
+                                <span>{{get theme.reviewableStatusCounts statusButton.status}}</span>
+                            {{/if}}
+                            {{#if isRequests}}
+                                <span class="fa-stack">
+                                    {{#each statusButton.iconClass as |class|}}
+                                        <i class="fa {{class}} fa-stack-1x"></i>
+                                    {{/each}}
+                                </span>
+                                <span>{{get theme.requestStatusCounts statusButton.status}}</span>
+                            {{/if}}
                             {{t statusButton.labelKey}}
                         </button>
                     {{/each}}
@@ -32,13 +46,29 @@
                     {{#if loading}}
                         {{moderation-list-row-skeleton}}
                     {{else}}
-                        {{#if (eq submissions.length 0)}}
+                        {{#if (and isSubmissions (eq submissions.length 0))}}
                             <div class="text-center p-v-md {{local-class 'moderation-list-row' from='reviews/components/moderation-list-row/styles'}}">
                                 {{t 'components.moderationList.noSubmissions'}}
                             </div>
                         {{else}}
                             {{#each submissions as |submission|}}
                                 {{moderation-list-row submission=submission}}
+                            {{/each}}
+                            <div class="pull-right text-right">
+                                {{pagination-pager
+                                    count=totalPages
+                                    current=page
+                                    change=(action pageChanged)
+                                }}
+                            </div>
+                        {{/if}}
+                        {{#if (and isRequests (eq requests.length 0))}}
+                            <div class="text-center p-v-md {{local-class 'moderation-list-row' from='reviews/components/moderation-list-row/styles'}}">
+                                {{t 'components.moderationList.noRequests'}}
+                            </div>
+                        {{else}}
+                            {{#each requests as |request|}}
+                                {{request-list-row request=request}}
                             {{/each}}
                             <div class="pull-right text-right">
                                 {{pagination-pager

--- a/app/components/preprint-status-banner/styles.scss
+++ b/app/components/preprint-status-banner/styles.scss
@@ -67,6 +67,30 @@
     }
 }
 
+.preprint-status-pending-withdrawal {
+    background-color: $color-state-warning-bg;
+    color: $color-state-warning-text;
+}
+
+.preprint-status-withdrawn {
+    background-color: $color-state-danger-bg;
+    color: $color-state-danger-text;
+
+    .status-icon {
+        font-size: 16px;
+        -webkit-text-stroke: 0;
+    }
+}
+
+.icon-stack {
+    height: 1.25em;
+    line-height: 1em;
+
+    & > .icon-layer-fa-minus {
+        font-size: 10px;
+    }
+}
+
 .status-badge {
     cursor: default;
     display: inline-block;  // required for the text-transform
@@ -117,6 +141,11 @@
         font-size: 1.4em;
     }
 
+    .withdrawal-justification {
+        padding-bottom: 5px;
+        padding-top: 10px;
+    }
+
     .feedback-header {
         border-bottom: 1px solid $color-border;
         font-size: 2em;
@@ -138,6 +167,10 @@
 
     .comment-length-error {
         color: $state-danger-text;
+    }
+
+    .withdrawal-reason {
+        font-style: italic;
     }
 }
 
@@ -161,7 +194,6 @@
 
         input {
             vertical-align: top;
-            width: 14px;  // prevents flex from making radio buttons smaller
         }
 
         p {

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -2,7 +2,11 @@
     <div local-class="flex-container">
         <div local-class="status-explanation">
             <span class="badge" local-class="{{getClassName}}">
-                <i class="fa {{icon}} status-icon" aria-hidden="true"></i>
+                <span class="fa-stack" local-class="icon-stack">
+                    {{#each icon as |class|}}
+                        <i class="fa fa-lg {{class}} fa-stack-1x status-icon" local-class="icon-layer-{{class}}"></i>
+                    {{/each}}
+                </span>
                 <span local-class="status-badge">{{t status}}</span>
                 {{#bs-tooltip placement="right"}}
                     {{t feedbackBaseMessage documentType=submission.provider.documentType}} {{t statusExplanation}}.
@@ -16,86 +20,158 @@
                 {{#if noActions}}
                     {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
                 {{else}}
-                    <a href={{creatorProfile}}>{{creatorName}}</a> {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
+                    <a href={{creatorProfile}}>{{creatorName}}</a> {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format labelDate "MMMM DD, YYYY"}}
+                    {{#if isPendingWithdrawal}}
+                        <br>
+                        <a href={{withdrawalRequesterProfile}}>{{withdrawalRequesterName}}</a> {{t requestActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
+                    {{/if}}
                 {{/if}}
             {{/if}}
         </div>
         <div class="dropdown" local-class="reviewer-feedback">
-            {{#bs-dropdown closeOnMenuClick=false as |dd|}}
-                {{#dd.button type="success" disabled=submission.reviewActions.isPending}}
-                    {{#if submission.reviewActions.isPending}}
-                        <i local-class="button-loading-indicator" class="fa fa-circle-o-notch fa-spin"></i>
-                        {{t 'components.preprint-status-banner.loading'}}
-                    {{else}}
+            {{#if isPendingWithdrawal}}
+                {{! If there is a pending withdrawal request }}
+                {{#bs-dropdown closeOnMenuClick=false as |dd|}}
+                    {{#dd.button type="success" disabled=submission.reviewActions.isPending}}
                         {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
-                    {{/if}}
-                {{/dd.button}}
-                {{#dd.menu}}
-                    <div local-class="feedback-header">
-                        <span id="moderator-feedback">{{t labelDecisionHeader}}</span>
-                        {{#dd.toggle aria-label="Close" id="close"}}
-                            <i class="fa fa-times"></i>
-                        {{/dd.toggle}}
-                    </div>
-                    <div local-class="setting-reminder" class="p-md">
-                        <div class="p-b-sm row">
-                            <i class="fa {{settingsCommentsIcon}} fa-lg col-xs-1"></i>
-                            <span class="col-xs-11">{{t settingsComments}}</span>
+                    {{/dd.button}}
+                    {{#dd.menu}}
+                        <div local-class="feedback-header">
+                            <span id="moderator-feedback">{{t labelDecisionHeader}}</span>
+                            {{#dd.toggle aria-label="Close" id="close"}}
+                                <i class="fa fa-times"></i>
+                            {{/dd.toggle}}
                         </div>
-                        {{#if (not reviewsCommentsPrivate)}}
-                            <div class="p-b-sm row">
-                                <i class="fa {{settingsNamesIcon}} fa-lg col-xs-1"></i>
-                                <span class="col-xs-11">{{t settingsNames}}</span>
+                        <div local-class="moderator-decision" aria-labelledby="moderator-feedback">
+                            <form local-class="{{if noComment 'no-comment'}}">
+                                <label local-class="decision-option">
+                                    {{radio-button value="accepted" groupValue=decision changed="decisionToggled"}}
+                                    <span class="p-l-sm">
+                                        {{t labelApprove}}
+                                        <p>{{t approveExplanation}}</p>
+                                    </span>
+                                </label>
+                                <label local-class="decision-option">
+                                    {{radio-button value="rejected" groupValue=decision changed="decisionToggled"}}
+                                    <span class="p-l-sm">
+                                        {{t labelDecline}}
+                                        <p>{{t declineExplanation}}</p>
+                                    </span>
+                                </label>
+                                {{#if (eq decision 'accepted')}}
+                                    <label local-class="withdrawal-justification">
+                                        <span class="p-l-sm">
+                                            {{t 'components.preprintStatusBanner.withdrawalJustification'}}
+                                        </span>
+                                    </label>
+                                    {{textarea
+                                        value=withdrawalJustification
+                                        rows="8"
+                                        class="form-control"
+                                    }}
+                                {{/if}}
+                            </form>
+                        </div>
+                        <div local-class="feedback-footer">
+                            <button class="btn btn-success pull-right" id="submit-btn" {{action "submit"}}>
+                                {{t labelDecisionBtn}}
+                            </button>
+                        </div>
+                    {{/dd.menu}}
+                {{/bs-dropdown}}
+            {{else}}
+                {{! If there is no pending withdrawal request }}
+                {{#bs-dropdown closeOnMenuClick=false as |dd|}}
+                    {{#dd.button type="success" disabled=isDisabled}}
+                        {{#if submission.reviewActions.isPending}}
+                            <i local-class="button-loading-indicator" class="fa fa-circle-o-notch fa-spin"></i>
+                            {{t 'components.preprint-status-banner.loading'}}
+                        {{else}}
+                            {{t labelDecisionDropdown}} <i class="fa fa-caret-down" aria-hidden="true"></i>
+                        {{/if}}
+                    {{/dd.button}}
+                    {{#if isDisabled}}
+                        {{#bs-tooltip placement='bottom'}}
+                            {{t 'components.preprintStatusBanner.noReasonProvided'}}
+                        {{/bs-tooltip}}
+                    {{/if}}
+                    {{#dd.menu}}
+                        <div local-class="feedback-header">
+                            <span id="moderator-feedback">{{t labelDecisionHeader}}</span>
+                            {{#dd.toggle aria-label="Close" id="close"}}
+                                <i class="fa fa-times"></i>
+                            {{/dd.toggle}}
+                        </div>
+                        {{#if (not (eq submission.reviewsState 'withdrawn'))}}
+                            <div local-class="setting-reminder" class="p-md">
+                                <div class="p-b-sm row">
+                                    <i class="fa {{settingsCommentsIcon}} fa-lg col-xs-1"></i>
+                                    <span class="col-xs-11">{{t settingsComments}}</span>
+                                </div>
+                                {{#if (not reviewsCommentsPrivate)}}
+                                    <div class="p-b-sm row">
+                                        <i class="fa {{settingsNamesIcon}} fa-lg col-xs-1"></i>
+                                        <span class="col-xs-11">{{t settingsNames}}</span>
+                                    </div>
+                                {{/if}}
+                                <div class="row">
+                                    <i class="fa {{settingsModerationIcon}} fa-lg col-xs-1"></i>
+                                    <span class="col-xs-11">{{t settingsModeration}}</span>
+                                </div>
+                            </div>
+                            <div local-class="moderator-decision" aria-labelledby="moderator-feedback">
+                                <form local-class="{{if noComment 'no-comment'}}">
+                                    <label local-class="decision-option">
+                                        {{radio-button value="accepted" groupValue=decision changed="decisionToggled"}}
+                                        <span class="p-l-sm">
+                                            {{t labelAccept}}
+                                            <p>{{t acceptExplanation}}</p>
+                                        </span>
+                                    </label>
+                                    <label local-class="decision-option">
+                                        {{radio-button value=radioDecision groupValue=decision changed="decisionToggled"}}
+                                        <span class="p-l-sm">
+                                            {{t labelDecision}}
+                                            <p>{{t rejectExplanation}}</p>
+                                        </span>
+                                    </label>
+                                    {{textarea
+                                        key-up=(action "commentChanged")
+                                        value=reviewerComment
+                                        rows="8" placeholder=(t commentPlaceholder)
+                                        class="form-control"
+                                    }}
+                                    {{#if commentExceedsLimit}}
+                                        <div local-class="comment-length-error">
+                                            {{commentLengthErrorMessage}}
+                                        </div>
+                                    {{/if}}
+                                </form>
+                            </div>
+                            <div local-class="feedback-footer">
+                                <button class="btn btn-success pull-right" id="submit-btn" disabled={{btnDisabled}} {{action "submit"}}>
+                                    {{t labelDecisionBtn}}
+                                </button>
+                                {{#if (not-eq submission.reviewsState 'pending')}}
+                                    {{#dd.toggle}}
+                                        <button class="btn btn-default pull-right" {{action "cancel"}}>
+                                            {{t "global.cancel"}}
+                                        </button>
+                                    {{/dd.toggle}}
+                                {{/if}}
+                            </div>
+                        {{else}}
+                            <div local-class="setting-reminder" class="p-md">
+                                <div class="p-b-sm row">
+                                    <span local-class="withdrawal-reason" class="col-xs-12">
+                                        {{latestAction.comment}}
+                                    </span>
+                                </div>
                             </div>
                         {{/if}}
-                        <div class="row">
-                            <i class="fa {{settingsModerationIcon}} fa-lg col-xs-1"></i>
-                            <span class="col-xs-11">{{t settingsModeration}}</span>
-                        </div>
-                    </div>
-                    <div local-class="moderator-decision" aria-labelledby="moderator-feedback">
-                        <form local-class="{{if noComment 'no-comment'}}">
-                            <label local-class="decision-option">
-                                {{radio-button value="accepted" groupValue=decision changed="decisionToggled"}}
-                                <span class="p-l-sm">
-                                    {{t labelAccept}}
-                                    <p>{{t acceptExplanation}}</p>
-                                </span>
-                            </label>
-                            <label local-class="decision-option">
-                                {{radio-button value="rejected" groupValue=decision changed="decisionToggled"}}
-                                <span class="p-l-sm">
-                                    {{t labelReject}}
-                                    <p>{{t rejectExplanation}}</p>
-                                </span>
-                            </label>
-                            {{textarea
-                                key-up=(action "commentChanged")
-                                value=reviewerComment
-                                rows="8" placeholder=(t commentPlaceholder)
-                                class="form-control"
-                            }}
-                            {{#if commentExceedsLimit}}
-                                <div local-class="comment-length-error">
-                                    {{commentLengthErrorMessage}}
-                                </div>
-                            {{/if}}
-                        </form>
-                    </div>
-                    <div local-class="feedback-footer">
-                        <button class="btn btn-success pull-right" id="submit-btn" disabled={{btnDisabled}} {{action "submit"}}>
-                            {{t labelDecisionBtn}}
-                        </button>
-                        {{#if (not-eq submission.reviewsState 'pending')}}
-                            {{#dd.toggle}}
-                                <button class="btn btn-default pull-right" {{action "cancel"}}>
-                                    {{t "global.cancel"}}
-                                </button>
-                            {{/dd.toggle}}
-                        {{/if}}
-                    </div>
-                {{/dd.menu}}
-            {{/bs-dropdown}}
+                    {{/dd.menu}}
+                {{/bs-dropdown}}
+            {{/if}}
         </div>
     </div>
 </div>

--- a/app/components/request-list-row/component.js
+++ b/app/components/request-list-row/component.js
@@ -1,0 +1,87 @@
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+
+import moment from 'moment';
+
+import latestAction from 'reviews/utils/latest-action';
+
+const ACCEPTED = 'accepted';
+const REJECTED = 'rejected';
+const AUTO_ACCEPTED = 'automaticallyAccepted';
+
+const submittedOnLabel = {
+    gtDay: 'components.requestListRow.submission.requestedOn',
+    ltDay: 'components.requestListRow.submission.requested',
+};
+
+const ACTION_LABELS = Object.freeze({
+    [ACCEPTED]: {
+        gtDay: 'components.requestListRow.submission.approvedOn',
+        ltDay: 'components.requestListRow.submission.approved',
+    },
+    [AUTO_ACCEPTED]: {
+        gtDay: 'components.requestListRow.submission.approvedAutomaticallyOn',
+        ltDay: 'components.requestListRow.submission.approvedAutomatically',
+    },
+    [REJECTED]: {
+        gtDay: 'components.requestListRow.submission.declinedOn',
+        ltDay: 'components.requestListRow.submission.declined',
+    },
+});
+
+
+export default Component.extend({
+    theme: service(),
+    i18n: service(),
+
+    localClassNames: ['moderation-list-row'],
+
+    latestActionCreator: computed.alias('latestAction.creator.fullName'),
+
+    latestAction: computed('request.actions', function() {
+        return latestAction(this.get('request.actions'));
+    }),
+
+    hasDecision: computed('request.machineState', function() {
+        return this.get('request.machineState') !== 'pending';
+    }),
+
+    decisionOnLabel: computed('request.{machineState,dateLastTransitioned}', 'latestActionCreator', 'latestAction', function() {
+        const i18n = this.get('i18n');
+        const [acceptedRejectedDate, gtDay] = this.formattedDateLabel(this.get('request.dateLastTransitioned'));
+        const dayValue = gtDay ? 'gtDay' : 'ltDay';
+        let status = null;
+        if (this.get('latestAction.auto')) {
+            status = 'automaticallyAccepted';
+        } else {
+            status = this.get('request.machineState');
+        }
+        const labels = ACTION_LABELS[status][dayValue];
+        return i18n.t(labels, { timeDate: acceptedRejectedDate, moderatorName: this.get('latestActionCreator') });
+    }),
+
+    requestedOnLabel: computed('request.{created,creator.fullName}', function() {
+        const i18n = this.get('i18n');
+        const [submitDate, gtDaySubmit] = this.formattedDateLabel(this.get('request.created'));
+        const dayValue = gtDaySubmit ? 'gtDay' : 'ltDay';
+        const labels = submittedOnLabel[dayValue];
+        return i18n.t(labels, { timeDate: submitDate, submitterName: this.get('request.creator.fullName') });
+    }),
+
+    didReceiveAttrs() {
+        this.iconClass = {
+            accepted: 'fa-check-circle-o accepted',
+            pending: 'fa-hourglass-o pending',
+            rejected: 'fa-times-circle-o rejected',
+        };
+    },
+
+    formattedDateLabel(rawDate) {
+        const gtDayAgo = moment().diff(rawDate, 'days') > 1;
+        const formattedDate = gtDayAgo ?
+            moment(rawDate).format('MMMM DD, YYYY') :
+            moment(Math.min(Date.parse(rawDate), Date.now())).fromNow();
+        return [formattedDate, gtDayAgo];
+    },
+});

--- a/app/components/request-list-row/styles.scss
+++ b/app/components/request-list-row/styles.scss
@@ -25,22 +25,6 @@
     color: $color-action-accept;
 }
 
-.withdrawn {
-    color: $color-action-reject;
-    
-    &:nth-child(2) {
-        font-size: 13px;
-        padding-left: 24px;
-        line-height: 2.5em;
-
-        @media screen and (max-width: 731px) {
-            font-size: 10px;
-            padding-left: 22px;
-            line-height: inherit;
-        }
-    }
-}
-
 .submission-info {
     padding: 10px 20px;
     color: $color-text-gray-dark;

--- a/app/components/request-list-row/template.hbs
+++ b/app/components/request-list-row/template.hbs
@@ -1,0 +1,18 @@
+{{#if fetchData.isRunning}}
+    {{moderation-list-row-skeleton}}
+{{else}}
+    {{#link-to 'preprints.provider.preprint-detail' theme.id request.target.id}}
+        <div data-status={{request.target.reviewsState}} local-class="flex-container">
+            <i class="fa fa-lg {{get iconClass request.machineState}}" local-class="{{get iconClass request.machineState}} status-icon"></i>
+            <div title={{request.target.title}} local-class="submission-info">
+                <div local-class="submission-title">{{request.target.title}}</div>
+                <div local-class="submission-body">
+                    <div>{{requestedOnLabel}}</div>
+                    {{#if hasDecision}}
+                        <div>{{decisionOnLabel}}</div>
+                    {{/if}}
+                </div>
+            </div>
+        </div>
+    {{/link-to}}
+{{/if}}

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -32,7 +32,9 @@ export default Controller.extend({
     fullScreenMFR: false,
     savingAction: false,
     showLicense: false,
-
+    isWithdrawn: false,
+    withdrawalRequest: null,
+    isPendingWithdrawal: false,
     userHasEnteredReview: false,
     showWarning: false,
     previousTransition: null,
@@ -104,26 +106,53 @@ export default Controller.extend({
                 previousTransition.retry();
             }
         },
-        submitDecision(trigger, comment, filter) {
+        submitReviewsDecision(trigger, comment, filter) {
             this.toggleProperty('savingAction');
+
             const action = this.store.createRecord('review-action', {
                 actionTrigger: trigger,
                 target: this.get('preprint'),
             });
+            const actionType = 'reviews';
 
             if (comment) {
                 action.comment = comment;
             }
+            this._saveAction(action, actionType, filter);
+        },
+        submitRequestsDecision(trigger, comment, filter) {
+            this.toggleProperty('savingAction');
 
-            this._saveAction(action, filter);
+            const action = this.store.createRecord('preprint-request-action', {
+                actionTrigger: trigger,
+                target: this.get('withdrawalRequest'),
+            });
+            const actionType = 'withdrawal';
+
+            if (comment) {
+                action.comment = comment;
+            }
+            this._saveAction(action, actionType, filter);
         },
     },
 
-    _saveAction(action, filter) {
-        return action.save()
-            .then(this._toModerationList.bind(this, { status: filter, page: 1, sort: '-date_last_transitioned' }))
-            .catch(this._notifySubmitFailure.bind(this))
-            .finally(() => this.set('savingAction', false));
+    _saveAction(action, actionType, filter) {
+        if (actionType === 'withdrawal') {
+            return action.save()
+                .then(this._toRequestList.bind(this, { status: filter, page: 1, sort: '-date_last_transitioned' }))
+                .catch(this._notifySubmitFailure.bind(this))
+                .finally(() => this.set('savingAction', false));
+        } else if (actionType === 'reviews') {
+            return action.save()
+                .then(this._toModerationList.bind(this, { status: filter, page: 1, sort: '-date_last_transitioned' }))
+                .catch(this._notifySubmitFailure.bind(this))
+                .finally(() => this.set('savingAction', false));
+        }
+    },
+
+    _toRequestList(queryParams) {
+        this.set('userHasEnteredReview', false);
+        this.transitionToRoute('preprints.provider.withdrawals', { queryParams });
     },
 
     _toModerationList(queryParams) {
@@ -141,11 +170,27 @@ export default Controller.extend({
             preprintId,
             { include: ['node', 'license', 'review_actions', 'contributors'] },
         ).catch(() => this.replaceWith('page-not-found'));
-
         this.set('preprint', response);
+        if (response.get('dateWithdrawn') !== null) {
+            this.set('isWithdrawn', true);
+        }
         this.set('authors', response.get('contributors'));
+        const node = yield response.get('node');
+        if (node && !node.get('public')) {
+            this.transitionToRoute('page-not-found');
+            return;
+        }
+        this.set('preprint', response);
+        let withdrawalRequest = yield this.get('preprint.requests');
+        withdrawalRequest = withdrawalRequest.toArray();
+        if (withdrawalRequest.length >= 1 && withdrawalRequest[0].get('machineState') === 'pending') {
+            this.set('withdrawalRequest', withdrawalRequest[0]);
+            this.set('isPendingWithdrawal', true);
+        } else {
+            this.set('withdrawalRequest', null);
+            this.set('isPendingWithdrawal', false);
+        }
         this.get('loadMathJax').perform();
-
         // required for breadcrumbs
         this.set('model.breadcrumbTitle', response.get('title'));
     }),

--- a/app/controllers/preprints/provider/withdrawals.js
+++ b/app/controllers/preprints/provider/withdrawals.js
@@ -1,0 +1,80 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+import QueryParams from 'ember-parachute';
+import { task } from 'ember-concurrency';
+
+import Analytics from 'ember-osf/mixins/analytics';
+
+
+export const moderationQueryParams = new QueryParams({
+    page: {
+        defaultValue: 1,
+        refresh: true,
+    },
+    sort: {
+        defaultValue: '-date_last_transitioned',
+        refresh: true,
+    },
+    status: {
+        defaultValue: 'pending',
+        refresh: true,
+    },
+});
+
+export default Controller.extend(Analytics, moderationQueryParams.Mixin, {
+    store: service(),
+    theme: service(),
+
+    actions: {
+        statusChanged(status) {
+            this.resetQueryParams(['page']);
+            this.set('status', status);
+        },
+        pageChanged(page) {
+            this.set('page', page);
+        },
+        sortChanged(sort) {
+            this.resetQueryParams(['page']);
+            this.set('sort', sort);
+        },
+    },
+
+    setup({ queryParams }) {
+        this.get('fetchData').perform(queryParams);
+    },
+
+    queryParamsDidChange({ shouldRefresh, queryParams }) {
+        if (shouldRefresh) {
+            this.get('fetchData').perform(queryParams);
+        }
+    },
+
+    reset(isExiting) {
+        if (isExiting) {
+            this.resetQueryParams();
+        }
+    },
+
+    fetchData: task(function* (queryParams) {
+        const providerId = this.get('theme.provider.id');
+        const response = yield this.get('store').query(
+            'preprint-request',
+            {
+                providerId,
+                filter: {
+                    machine_state: queryParams.status,
+                },
+                'meta[requests_state_counts]': true,
+                embed: 'target',
+                sort: queryParams.sort,
+                page: queryParams.page,
+            },
+        );
+        this.get('theme').set('requestStatusCounts', response.meta.requests_state_counts);
+        this.set('results', {
+            requests: response.toArray(),
+            totalPages: Math.ceil(response.meta.total / response.meta.per_page),
+        });
+    }),
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -17,6 +17,7 @@ export default {
         notifications: 'Notifications',
         submissions: 'Submissions',
         moderators: 'Moderators',
+        withdrawalRequests: 'Withdrawal Requests',
     },
     index: {
         feature: {
@@ -179,6 +180,7 @@ export default {
                 accept: 'accepted a {{documentType.singular}} in {{providerName}}',
                 reject: 'rejected a {{documentType.singular}} from {{providerName}}',
                 edit_comment: 'edited the comment for a {{documentType.singular}} in {{providerName}}',
+                withdraw: 'withdrew a {{documentType.singular}} from {{providerName}}',
             },
         },
         dashboardSidebar: {
@@ -207,8 +209,12 @@ export default {
             pending: 'Pending',
             accepted: 'Accepted',
             rejected: 'Rejected',
+            approved: 'Approved',
+            declined: 'Declined',
+            withdrawn: 'Withdrawn',
             sort: 'Sort',
             noSubmissions: 'No submissions.',
+            noRequests: 'No requests.',
         },
         moderationListRow: {
             submission: {
@@ -220,6 +226,20 @@ export default {
                 acceptedAutomatically: 'Accepted automatically {{timeDate}}',
                 rejectedOn: 'Rejected on {{timeDate}} by {{moderatorName}}',
                 rejected: 'Rejected {{timeDate}} by {{moderatorName}}',
+                withdrawnOn: 'Withdrawn on {{timeDate}} by {{moderatorName}}',
+                withdrawn: 'Withdrawn {{timeDate}} by {{moderatorName}}',
+            },
+        },
+        requestListRow: {
+            submission: {
+                requestedOn: 'Requested on {{timeDate}} by {{submitterName}}',
+                requested: 'Requested {{timeDate}} by {{submitterName}}',
+                approvedOn: 'Approved on {{timeDate}} by {{moderatorName}}',
+                approved: 'Approved {{timeDate}} by {{moderatorName}}',
+                approvedAutomaticallyOn: 'Approved automatically on {{timeDate}}',
+                approvedAutomatically: 'Approved automatically {{timeDate}}',
+                declinedOn: 'Declined on {{timeDate}} by {{moderatorName}}',
+                declined: 'Declined {{timeDate}} by {{moderatorName}}',
             },
         },
         notificationList: {
@@ -246,6 +266,8 @@ export default {
                 pending: 'submitted this {{documentType.singular}} on',
                 accepted: 'accepted this {{documentType.singular}} on',
                 rejected: 'rejected this {{documentType.singular}} on',
+                pendingWithdrawal: 'requested to withdraw this {{documentType.singular}} on',
+                withdrawn: 'withdrew this {{documentType.singular}} on',
                 automatic: {
                     pending: 'This {{documentType.singular}} was submitted on',
                     accepted: 'This {{documentType.singular}} was automatically accepted on',
@@ -256,17 +278,24 @@ export default {
                 pendingPost: 'publicly available and searchable but is subject to removal by a moderator',
                 accepted: 'publicly available and searchable',
                 rejected: 'not publicly available or searchable',
+                pendingWithdrawal: 'not public available or searchable once the withdrawal request is approved',
+                withdrawn: 'not publicly available',
             },
+            withdrawalJustification: 'Reason for withdrawal',
             pending: 'pending',
             accepted: 'accepted',
             rejected: 'rejected',
+            withdrawn: 'withdrawn',
             loading: 'Loading...',
+            noReasonProvided: 'No reason provided',
             decision: {
                 makeDecision: 'Make decision',
                 modifyDecision: 'Modify decision',
+                withdrawalReason: 'View reason',
                 header: {
                     submitDecision: 'Submit your decision',
                     modifyDecision: 'Modify your decision',
+                    withdrawalReason: 'Reason for withdrawal',
                 },
                 moderator: 'Moderator',
                 base: 'This {{documentType.singular}} is',
@@ -278,14 +307,26 @@ export default {
                 commentPlaceholder: 'Explain the reasoning behind your decision (optional)',
                 commentLengthError: 'Comment is {{difference}} character(s) too long (maximum is {{limit}}).',
                 accept: {
-                    label: 'Accept',
+                    label: 'Accept submission',
                     pre: 'Submission will appear in search results and be made public.',
                     post: 'Submission will continue to appear in search results.',
                 },
                 reject: {
-                    label: 'Reject',
+                    label: 'Reject submission',
                     pre: 'Submission will not appear in search results and will remain private.',
                     post: 'Submission will be removed from search results and made private.',
+                },
+                approve: {
+                    label: 'Approve withdrawal',
+                    explanation: 'Submission will be withdrawn but still have a tombstone page with a subset of the metadata available',
+                },
+                decline: {
+                    label: 'Decline withdrawal',
+                    explanation: 'Submission will remain fully public',
+                },
+                withdrawn: {
+                    label: 'Withdraw submission',
+                    post: 'Submission will no longer be publicly available.',
                 },
             },
             settings: {

--- a/app/router.js
+++ b/app/router.js
@@ -81,6 +81,7 @@ Router.map(function() {
             this.route('settings');
             this.route('preprint-detail', { path: ':preprint_id' });
             this.route('notifications');
+            this.route('withdrawals');
         });
     });
     this.route('dashboard');

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -12,6 +12,7 @@ export default Service.extend({
 
     provider: null,
     reviewableStatusCounts: null,
+    request: null,
 
     id: alias('provider.id'),
     domain: alias('provider.domain'),
@@ -57,6 +58,14 @@ export default Service.extend({
     _onProviderLoad(provider) {
         this.set('provider', provider);
         this.set('reviewableStatusCounts', provider.get('reviewableStatusCounts'));
+        this.get('store').query(
+            'preprint-request',
+            {
+                providerId: provider.id,
+                'meta[requests_state_counts]': true,
+            },
+        ).then(this._setRequestStatusCounts.bind(this));
+
         this.get('i18n').addGlobals({
             provider: {
                 id: this.get('provider.id'),
@@ -64,5 +73,9 @@ export default Service.extend({
             },
         });
         return provider;
+    },
+
+    _setRequestStatusCounts(response) {
+        this.set('requestStatusCounts', response.meta.requests_state_counts);
     },
 });

--- a/app/styles/preprints/provider/preprint-detail.scss
+++ b/app/styles/preprints/provider/preprint-detail.scss
@@ -129,6 +129,10 @@
             min-height: 100px;
         }
     }
+
+    .withdrawn-column {
+        margin-bottom: 50px;
+    }
 }
 
 .content-provider-logo {

--- a/app/templates/preprints/provider/preprint-detail.hbs
+++ b/app/templates/preprints/provider/preprint-detail.hbs
@@ -61,141 +61,210 @@
         {{#if (or fetchData.isRunning (not preprint))}}
             <div local-class="preprint-status-component--skeleton"></div>
         {{else}}
-            {{preprint-status-banner submission=preprint saving=savingAction setUserEnteredReview=(action (mut userHasEnteredReview)) submitDecision=(action 'submitDecision')}}
+            {{preprint-status-banner submission=preprint withdrawalRequest=withdrawalRequest isPendingWithdrawal=isPendingWithdrawal saving=savingAction setUserEnteredReview=(action (mut userHasEnteredReview)) submitReviewsDecision=(action 'submitReviewsDecision') submitRequestsDecision=(action 'submitRequestsDecision')}}
         {{/if}}
     </div>
 
     <div local-class="view-page">
         <div class="container">
             <div class="row p-md">
-                <div local-class="mfr-col" class="col-md-{{if fullScreenMFR '12' '7'}}">
-                    {{#if fetchData.isRunning}}
-                        {{file-renderer-skeleton}}
-                    {{else}}
-                        {{preprint-file-browser primaryFile=preprint.primaryFile preprint=preprint fileDownloadURL=fileDownloadURL}}
-                    {{/if}}
-                    <button local-class="expand-mfr-carrot" class="hidden-xs hidden-sm" {{action 'expandMFR'}}>
-                        <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
-                    </button>
-                </div>
-
-                <div class="col-md-5 {{if fullScreenMFR 'hidden' ''}}">
-                    {{#if fetchData.isRunning}}
-                        {{#content-placeholders as |placeholder|}}
-                            {{placeholder.img}}
-                            {{#each dummyMetaData}}
-                                <div class="m-v-lg">
-                                    {{placeholder.heading subtitle=false}}
-                                    {{placeholder.text lines=2}}
-                                </div>
-                            {{/each}}
-                        {{/content-placeholders}}
-                    {{else}}
-                        <div class="p-sm osf-box-lt clearfix" local-class="share-row osf-box-lt">
-                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}}>
-                                {{t "content.share.downloadPreprint" documentType=preprint.provider.documentType}}
-                            </a>
-                            <div class="p-v-xs pull-right">
-                                {{t "content.share.downloads"}}: {{preprint.primaryFile.extra.downloads}}
-                            </div>
-                        </div>
-
-                        <div class="p-t-md pull-right">
-                            <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-twitter-square"></i>
-                            </a>
-                            <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-facebook-square"></i>
-                            </a>
-                            <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-linkedin-square"></i>
-                            </a>
-                            <a class="text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
-                                <i class="fa fa-2x fa-envelope"></i>
-                            </a>
-                        </div>
-
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
-                            <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
-                                {{~if useShortenedDescription description preprint.description~}}
-                            </p>
-                            <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
-                                {{~t (if expandedAbstract 'content.seeLess' 'content.seeMore')~}}
-                            </button>
-                        </div>
-
-                        <section class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI"}}</strong></h4>
-                            {{#if preprint.isPublished}}
-                                {{#if preprint.preprintDoiCreated}}
-                                    <a href={{preprint.preprintDoiUrl}}>{{extract-doi preprint.preprintDoiUrl}}</a>
-                                {{else}}
-                                    <p> {{extract-doi preprint.preprintDoiUrl}} </p>
-                                    <p> {{t "content.preprintPendingDOIMinted"}} </p>
-                                {{/if}}
-                            {{else}}
-                                {{t 'content.preprintPendingDOI'}}
-                            {{/if}}
-                        </section>
-
-                        {{#if preprint.articleDoiUrl}}
-                            <section class="p-t-xs">
-                                <h4 class="p-v-md f-w-md"><strong>{{t "content.articleDOI"}}</strong></h4>
-                                <a href={{preprint.articleDoiUrl}}>{{preprint.doi}}</a>
-                            </section>
+                {{#if (not isWithdrawn)}}
+                    <div local-class="mfr-col" class="col-md-{{if fullScreenMFR '12' '7'}}">
+                        {{#if fetchData.isRunning}}
+                            {{file-renderer-skeleton}}
+                        {{else}}
+                            {{preprint-file-browser primaryFile=preprint.primaryFile preprint=preprint fileDownloadURL=fileDownloadURL}}
                         {{/if}}
+                        <button local-class="expand-mfr-carrot" class="hidden-xs hidden-sm" {{action 'expandMFR'}}>
+                            <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
+                        </button>
+                    </div>
 
-                        {{#if preprint.license.name}}
-                            <section local-class="preprint-license" class="p-t-xs">
-                                <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
-                                {{preprint.license.name}}
-                                <span  onclick={{action 'toggleShowLicense'}} role="button">
-                                    <i class="fa fa-caret-{{if showLicense 'down' 'right'}}"></i>
-                                </span>
-                                {{#if showLicense}}
-                                    <pre>{{preprint.licenseText}}</pre>
-                                {{/if}}
-                            </section>
-                        {{/if}}
-
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
-                            {{#each preprint.uniqueSubjects as |subject|}}
-                                <span local-class="subject-preview">{{subject.text}}</span>
-                            {{/each}}
-                        </div>
-
-                        <div class="p-t-xs">
-                            <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
-                            {{#if hasTags}}
-                                {{#each preprint.tags as |tag|}}
-                                    <span class="badge">{{fix-special-char tag}}</span>
+                    <div class="col-md-5 {{if fullScreenMFR 'hidden' ''}}">
+                        {{#if fetchData.isRunning}}
+                            {{#content-placeholders as |placeholder|}}
+                                {{placeholder.img}}
+                                {{#each dummyMetaData}}
+                                    <div class="m-v-lg">
+                                        {{placeholder.heading subtitle=false}}
+                                        {{placeholder.text lines=2}}
+                                    </div>
                                 {{/each}}
+                            {{/content-placeholders}}
+                        {{else}}
+                            <div class="p-sm osf-box-lt clearfix" local-class="share-row osf-box-lt">
+                                <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}}>
+                                    {{t "content.share.downloadPreprint" documentType=preprint.provider.documentType}}
+                                </a>
+                                <div class="p-v-xs pull-right">
+                                    {{t "content.share.downloads"}}: {{preprint.primaryFile.extra.downloads}}
+                                </div>
+                            </div>
+
+                            <div class="p-t-md pull-right">
+                                <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-twitter-square"></i>
+                                </a>
+                                <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-facebook-square"></i>
+                                </a>
+                                <a class="m-r-xs text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-linkedin-square"></i>
+                                </a>
+                                <a class="text-smaller disabled" href='' onclick="return false;" aria-hidden="true">
+                                    <i class="fa fa-2x fa-envelope"></i>
+                                </a>
+                            </div>
+
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
+                                <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
+                                    {{~if useShortenedDescription description preprint.description~}}
+                                </p>
+                                <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
+                                    {{~t (if expandedAbstract 'content.seeLess' 'content.seeMore')~}}
+                                </button>
+                            </div>
+
+                            <section class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI"}}</strong></h4>
+                                {{#if preprint.isPublished}}
+                                    {{#if preprint.preprintDoiCreated}}
+                                        <a href={{preprint.preprintDoiUrl}}>{{extract-doi preprint.preprintDoiUrl}}</a>
+                                    {{else}}
+                                        <p> {{extract-doi preprint.preprintDoiUrl}} </p>
+                                        <p> {{t "content.preprintPendingDOIMinted"}} </p>
+                                    {{/if}}
+                                {{else}}
+                                    {{t 'content.preprintPendingDOI'}}
+                                {{/if}}
+                            </section>
+
+                            {{#if preprint.articleDoiUrl}}
+                                <section class="p-t-xs">
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "content.articleDOI"}}</strong></h4>
+                                    <a href={{preprint.articleDoiUrl}}>{{preprint.doi}}</a>
+                                </section>
+                            {{/if}}
+
+                            {{#if preprint.license.name}}
+                                <section local-class="preprint-license" class="p-t-xs">
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
+                                    {{preprint.license.name}}
+                                    <span  onclick={{action 'toggleShowLicense'}} role="button">
+                                        <i class="fa fa-caret-{{if showLicense 'down' 'right'}}"></i>
+                                    </span>
+                                    {{#if showLicense}}
+                                        <pre>{{preprint.licenseText}}</pre>
+                                    {{/if}}
+                                </section>
+                            {{/if}}
+
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
+                                {{#each preprint.uniqueSubjects as |subject|}}
+                                    <span local-class="subject-preview">{{subject.text}}</span>
+                                {{/each}}
+                            </div>
+
+                            <div class="p-t-xs">
+                                <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
+                                {{#if hasTags}}
+                                    {{#each preprint.tags as |tag|}}
+                                        <span class="badge">{{fix-special-char tag}}</span>
+                                    {{/each}}
+                                {{else}}
+                                    {{t "global.none"}}
+                                {{/if}}
+                            </div>
+
+                            <div class="p-t-xs m-b-lg">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.citations"}}</strong></h4>
+                                {{citation-widget node=preprint}}
+                            </div>
+                        {{/if}}
+                    </div>
+                {{else}}
+                    <div class="row p-md" local-class="withdrawn-column">
+                        <div class="col-md-7">
+                            {{#if fetchData.isRunning}}
+                                {{#content-placeholders as |placeholder|}}
+                                    {{placeholder.img}}
+                                    {{#each dummyMetaData}}
+                                        <div class="m-v-lg">
+                                            {{placeholder.heading subtitle=false}}
+                                            {{placeholder.text lines=2}}
+                                        </div>
+                                    {{/each}}
+                                {{/content-placeholders}}
                             {{else}}
-                                {{t "global.none"}}
+                                <div class="p-t-xs">
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
+                                    <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
+                                        {{~if useShortenedDescription description preprint.description~}}
+                                    </p>
+                                    <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
+                                        {{~t (if expandedAbstract 'content.seeLess' 'content.seeMore')~}}
+                                    </button>
+                                </div>
+
+                                <section class="p-t-xs">
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "content.preprintDOI" documentType=preprint.provider.documentType}}</strong></h4>
+                                    {{#if preprint.isPublished}}
+                                        {{#if preprint.preprintDoiCreated}}
+                                            <a href={{preprint.preprintDoiUrl}}>{{extract-doi preprint.preprintDoiUrl}}</a>
+                                        {{/if}}
+                                    {{else}}
+                                        {{t "global.none"}}
+                                    {{/if}}
+                                </section>
+
+                                {{#if preprint.license.name}}
+                                    <section local-class="preprint-license" class="p-t-xs">
+                                        <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
+                                        {{preprint.license.name}}
+                                        <span  onclick={{action 'toggleShowLicense'}} role="button">
+                                            <i class="fa fa-caret-{{if showLicense 'down' 'right'}}"></i>
+                                        </span>
+                                        {{#if showLicense}}
+                                            <pre>{{preprint.licenseText}}</pre>
+                                        {{/if}}
+                                    </section>
+                                {{/if}}
+
+                                <div class="p-t-xs">
+                                    <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
+                                    {{#each preprint.uniqueSubjects as |subject|}}
+                                        <span local-class="subject-preview">{{subject.text}}</span>
+                                    {{/each}}
+                                </div>
+
+                                <div class="p-t-xs">
+                                    <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
+                                    {{#if hasTags}}
+                                        {{#each preprint.tags as |tag|}}
+                                            <span class="badge">{{fix-special-char tag}}</span>
+                                        {{/each}}
+                                    {{else}}
+                                        {{t "global.none"}}
+                                    {{/if}}
+                                </div>
                             {{/if}}
                         </div>
-
-                        <div class="p-t-xs m-b-lg">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.citations"}}</strong></h4>
-                            {{citation-widget node=preprint}}
-                        </div>
-                    {{/if}}
-                </div>
-
+                    </div>
+                {{/if}}
             </div>
         </div>
-    </div>
 
-    {{#bs-modal open=showWarning onHide=(action (mut showWarning false)) as |modal|}}
-        {{#modal.header}}
-            <div class="warning-header"><i class="fa fa-exclamation-triangle"></i> {{t 'content.warning.header'}}</div>
-        {{/modal.header}}
-        {{#modal.body}}<div class="warning-body">{{t 'content.warning.body'}}</div>{{/modal.body}}
-        {{#modal.footer}}
-            {{#bs-button onClick=(action modal.close)}}{{t 'content.warning.footer.stay'}}{{/bs-button}}
-            {{#bs-button onClick=(action 'leavePage') type="primary"}}{{t 'content.warning.footer.leave'}}{{/bs-button}}
-        {{/modal.footer}}
-    {{/bs-modal}}
+        {{#bs-modal open=showWarning onHide=(action (mut showWarning false)) as |modal|}}
+            {{#modal.header}}
+                <div class="warning-header"><i class="fa fa-exclamation-triangle"></i> {{t 'content.warning.header'}}</div>
+            {{/modal.header}}
+            {{#modal.body}}<div class="warning-body">{{t 'content.warning.body'}}</div>{{/modal.body}}
+            {{#modal.footer}}
+                {{#bs-button onClick=(action modal.close)}}{{t 'content.warning.footer.stay'}}{{/bs-button}}
+                {{#bs-button onClick=(action 'leavePage') type="primary"}}{{t 'content.warning.footer.leave'}}{{/bs-button}}
+            {{/modal.footer}}
+        {{/bs-modal}}
+    </div>
 </div>

--- a/app/templates/preprints/provider/withdrawals.hbs
+++ b/app/templates/preprints/provider/withdrawals.hbs
@@ -2,8 +2,8 @@
     statusChanged=(action 'statusChanged')
     pageChanged=(action 'pageChanged')
     sortChanged=(action 'sortChanged')
-    submissions=results.submissions
-    isSubmissions=true
+    requests=results.requests
+    isRequests=true
     page=page
     sort=sort
     status=status

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "use-ember-osf-next-interfaces": "yarn upgrade @centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#release/next-interfaces#$(date -u +%FT%TZ)"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "0.23.0",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-03-13T20:56:09Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.9.0",
     "@cos-forks/ember-content-placeholders": "https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc",

--- a/tests/integration/components/moderation-list/component-test.js
+++ b/tests/integration/components/moderation-list/component-test.js
@@ -38,6 +38,7 @@ test('moderation-list no submissions', function(assert) {
             sortChanged=sortChanged
             submissions=submissions
             page=1
+            isSubmissions=true
             sort='-date_last_transitioned'
             status='pending'
             loading=false

--- a/tests/integration/components/preprint-status-banner/component-test.js
+++ b/tests/integration/components/preprint-status-banner/component-test.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/named-functions-in-promises */
+// Putting the lines after wait() into a named function is not really helpful for tests' readability
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
@@ -8,14 +10,15 @@ moduleForComponent('preprint-status-banner', 'Integration | Component | preprint
     integration: true,
 });
 
-test('it renders preprint-status-banner', function(assert) {
+test('it renders preprint-status-banner pre-moderation', function(assert) {
     this.set('submitDecision', () => {});
     this.set('setUserEnteredReview', () => {});
     this.set('savingAction', false);
     this.set('submission', {
         dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
         reviewActions: new Promise(function(resolve) { resolve([]); }),
-        reviewsState: 'accepted',
+        reviewsState: 'pending',
+        isPublished: false,
         provider: { reviewsWorkflow: 'pre-moderation' },
         node: { contributors: [{ users: { fullName: 'Mr. Ping' } }, { users: { fullName: 'Mantis' } }] },
     });
@@ -24,43 +27,114 @@ test('it renders preprint-status-banner', function(assert) {
         .then(() => {
             assert.ok(this.$(`.${styles['flex-container']}`).length);
             assert.equal(
+                this.$(`.${styles['reviewer-feedback']}`).text().replace(/\s+/g, ' ').trim(),
+                'Make decision Submit your decision Comments are visible to contributors on decision Commenter\'s name' +
+                ' is visible to contributors Submission appears in search results once accepted Accept submission Submission will' +
+                ' appear in search results and be made public. Reject submission Submission will not appear in search results and' +
+                ' will remain private. Submit decision',
+            );
+            assert.equal(
+                this.$(`.${styles['recent-activity']}`).text().replace(/\s+/g, ' ').trim(),
+                'This was submitted on October 27, 2017',
+            );
+            assert.equal(this.$(`.${styles['status-explanation']}`).text().replace(/\s+/g, ' ').trim(), 'pending');
+
+            this.set('submission.isPublished', true);
+            this.set('submission.reviewsState', 'accepted');
+
+            assert.equal(
                 this.$(`.${styles['recent-activity']}`).text().replace(/\s+/g, ' ').trim(),
                 'This was automatically accepted on October 27, 2017',
             );
             assert.equal(
                 this.$(`.${styles['reviewer-feedback']}`).text().replace(/\s+/g, ' ').trim(),
                 'Modify decision Modify your decision Comments are visible to contributors on decision Commenter\'s' +
-                ' name is visible to contributors Submission appears in search results once accepted Accept Submission' +
-                ' will appear in search results and be made public. Reject Submission will not appear in search results' +
+                ' name is visible to contributors Submission appears in search results once accepted Accept submission Submission' +
+                ' will appear in search results and be made public. Reject submission Submission will not appear in search results' +
                 ' and will remain private. Modify decision Cancel',
             );
             assert.equal(this.$(`.${styles['status-explanation']}`).text().replace(/\s+/g, ' ').trim(), 'accepted');
+        });
+});
 
-            this.set('submission.reviewsState', 'pending');
+test('it renders preprint-status-banner post-moderation', function(assert) {
+    this.set('submitDecision', () => {});
+    this.set('setUserEnteredReview', () => {});
+    this.set('savingAction', false);
+    this.set('submission', {
+        dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        reviewActions: new Promise(function(resolve) { resolve([]); }),
+        reviewsState: 'pending',
+        isPublished: true,
+        provider: { reviewsWorkflow: 'post-moderation' },
+        node: { contributors: [{ users: { fullName: 'Mr. Ping' } }, { users: { fullName: 'Mantis' } }] },
+    });
 
-            assert.equal(
-                this.$(`.${styles['reviewer-feedback']}`).text().replace(/\s+/g, ' ').trim(),
-                'Make decision Submit your decision Comments are visible to contributors on decision Commenter\'s name' +
-                ' is visible to contributors Submission appears in search results once accepted Accept Submission will' +
-                ' appear in search results and be made public. Reject Submission will not appear in search results and' +
-                ' will remain private. Submit decision',
-            );
+    this.render(hbs`{{preprint-status-banner submission=submission saving=savingAction setUserEnteredReview=setUserEnteredReview submitDecision=submitDecision}}`);
+    return wait()
+        .then(() => {
+            assert.ok(this.$(`.${styles['flex-container']}`).length);
 
-            assert.equal(
-                this.$(`.${styles['recent-activity']}`).text().replace(/\s+/g, ' ').trim(),
-                'This was submitted on October 27, 2017',
-            );
-
-            assert.equal(this.$(`.${styles['status-explanation']}`).text().replace(/\s+/g, ' ').trim(), 'pending');
-
-            this.set('submission.provider.reviewsWorkflow', 'post-moderation');
-
+            /* Test for Pending */
             assert.equal(
                 this.$(`.${styles['reviewer-feedback']}`).text().replace(/\s+/g, ' ').trim(),
                 'Make decision Submit your decision Comments are visible to contributors on decision Commenter\'s name' +
                 ' is visible to contributors Submission will be removed from search results and made private if rejected' +
-                ' Accept Submission will continue to appear in search results. Reject Submission will be removed from' +
-                ' search results and made private. Submit decision',
+                ' Accept submission Submission will continue to appear in search results. Withdraw submission Submission will no longer be publicly' +
+                ' available. Submit decision',
+            );
+            assert.equal(
+                this.$(`.${styles['recent-activity']}`).text().replace(/\s+/g, ' ').trim(),
+                'This was submitted on October 27, 2017',
+            );
+            assert.equal(this.$(`.${styles['status-explanation']}`).text().replace(/\s+/g, ' ').trim(), 'pending');
+
+            /* Test for Accepted */
+            this.set('submission.reviewsState', 'accepted');
+
+            assert.equal(
+                this.$(`.${styles['recent-activity']}`).text().replace(/\s+/g, ' ').trim(),
+                'This was automatically accepted on October 27, 2017',
+            );
+            assert.equal(
+                this.$(`.${styles['reviewer-feedback']}`).text().replace(/\s+/g, ' ').trim(),
+                'Modify decision Modify your decision Comments are visible to contributors on decision Commenter\'s name' +
+                ' is visible to contributors Submission will be removed from search results and made private if rejected' +
+                ' Accept submission Submission will continue to appear in search results. Withdraw submission Submission will no longer be publicly' +
+                ' available. Modify decision Cancel',
+            );
+            assert.equal(this.$(`.${styles['status-explanation']}`).text().replace(/\s+/g, ' ').trim(), 'accepted');
+        });
+});
+
+test('it renders withdrawn', function(assert) {
+    this.set('submitDecision', () => {});
+    this.set('setUserEnteredReview', () => {});
+    this.set('savingAction', false);
+    this.set('submission', {
+        dateLastTransitioned: '2017-10-27T19:14:27.816946Z',
+        reviewActions: new Promise(function(resolve) { resolve([]); }),
+        reviewsState: 'withdrawn',
+        isPublished: true,
+        provider: { reviewsWorkflow: 'post-moderation' },
+        node: { contributors: [{ users: { fullName: 'Mr. Ping' } }, { users: { fullName: 'Mantis' } }] },
+    });
+    this.set('latestAction', {
+        actionTrigger: 'withdraw',
+        fromState: 'pending',
+        toState: 'withdrawn',
+        comment: 'this is a test reason',
+    });
+
+    this.render(hbs`{{preprint-status-banner submission=submission saving=savingAction setUserEnteredReview=setUserEnteredReview submitDecision=submitDecision latestAction=latestAction}}`);
+    return wait()
+        .then(() => {
+            assert.ok(this.$(`.${styles['flex-container']}`).length);
+
+            assert.equal(
+                this.$(`.${styles['reviewer-feedback']}`).text().replace(/\s+/g, ' ').trim(),
+                'View reason Reason for withdrawal this is a test reason',
             );
         });
 });
+/* eslint-enable ember/named-functions-in-promises */

--- a/tests/unit/components/preprint-status-banner-test.js
+++ b/tests/unit/components/preprint-status-banner-test.js
@@ -164,8 +164,9 @@ test('submit action', function(assert) {
         component.set('decisionChanged', false);
         component.set('decision', 'accepted');
         component.set('commentEdited', true);
-        component.set('submitDecision', () => {});
-        const stub = this.stub(component, 'submitDecision');
+        component.set('isPendingWithdrawal', false);
+        component.set('submitReviewsDecision', () => {});
+        const stub = this.stub(component, 'submitReviewsDecision');
 
         component.send('submit');
         assert.ok(stub.calledOnce);

--- a/tests/unit/controllers/preprints/provider/preprint-detail-test.js
+++ b/tests/unit/controllers/preprints/provider/preprint-detail-test.js
@@ -170,7 +170,7 @@ test('expandAbstract action', function (assert) {
     assert.strictEqual(ctrl.get('expandedAbstract'), initialValue);
 });
 
-test('submitDecision action', function (assert) {
+test('submitReviewsDecision action', function (assert) {
     this.inject.service('store');
     const ctrl = this.subject();
 
@@ -186,15 +186,43 @@ test('submitDecision action', function (assert) {
 
         const stub = this.stub(ctrl, '_saveAction');
 
-        ctrl.send('submitDecision', 'accept', 'yes', 'accepted');
+        ctrl.send('submitReviewsDecision', 'accept', 'yes', 'accepted');
         assert.strictEqual(ctrl.get('userHasEnteredReview'), false);
         assert.strictEqual(ctrl.get('savingAction'), !initialValue);
-        assert.ok(stub.calledWithExactly(action, 'accepted'), 'correct arguments passed to _saveAction');
+        assert.ok(stub.calledWithExactly(action, 'reviews', 'accepted'), 'correct arguments passed to _saveAction');
 
-        ctrl.send('submitDecision', 'reject', 'no', 'rejected');
+        ctrl.send('submitReviewsDecision', 'reject', 'no', 'rejected');
         assert.strictEqual(ctrl.get('userHasEnteredReview'), false);
         assert.strictEqual(ctrl.get('savingAction'), initialValue);
-        assert.ok(stub.calledWithExactly(action, 'rejected'), 'correct arguments passed to _saveAction');
+        assert.ok(stub.calledWithExactly(action, 'reviews', 'rejected'), 'correct arguments passed to _saveAction');
+    });
+});
+
+test('submitRequestsDecision action', function (assert) {
+    this.inject.service('store');
+    const ctrl = this.subject();
+
+    run(() => {
+        const initialValue = ctrl.get('savingAction');
+
+        const action = {
+            comment: '',
+            save() { return (new Promise(function(resolve) { resolve('hello'); })); },
+        };
+
+        ctrl.set('store.createRecord', () => { return action; });
+
+        const stub = this.stub(ctrl, '_saveAction');
+
+        ctrl.send('submitRequestsDecision', 'accept', 'yes', 'accepted');
+        assert.strictEqual(ctrl.get('userHasEnteredReview'), false);
+        assert.strictEqual(ctrl.get('savingAction'), !initialValue);
+        assert.ok(stub.calledWithExactly(action, 'withdrawal', 'accepted'), 'correct arguments passed to _saveAction');
+
+        ctrl.send('submitRequestsDecision', 'reject', 'no', 'rejected');
+        assert.strictEqual(ctrl.get('userHasEnteredReview'), false);
+        assert.strictEqual(ctrl.get('savingAction'), initialValue);
+        assert.ok(stub.calledWithExactly(action, 'withdrawal', 'rejected'), 'correct arguments passed to _saveAction');
     });
 });
 

--- a/tests/unit/services/theme-test.js
+++ b/tests/unit/services/theme-test.js
@@ -1,14 +1,18 @@
 import { getOwner } from '@ember/application';
 import EmberObject from '@ember/object';
 import { moduleFor, test } from 'ember-qunit';
+import DS from 'ember-data';
+import { resolve } from 'rsvp';
 
 import tHelper from 'ember-i18n/helper';
 import localeConfig from 'ember-i18n/config/en';
 
+const { PromiseObject } = DS;
 
 moduleFor('service:theme', 'Unit | Service | theme', {
     needs: [
         'service:i18n',
+        'model:preprint-request',
         'locale:en/translations',
         'locale:en/config',
         'util:i18n/missing-message',
@@ -26,7 +30,24 @@ moduleFor('service:theme', 'Unit | Service | theme', {
 });
 
 test('_onProviderLoad', function(assert) {
-    const service = this.subject();
+    const service = this.subject({
+        store: {
+            query: () => {
+                return PromiseObject.create({
+                    promise: resolve({
+                        meta: {
+                            request_status_counts: {
+                                pending: 2,
+                                accepted: 1,
+                                rejected: 3,
+                                initial: 0,
+                            },
+                        },
+                    }),
+                });
+            },
+        },
+    });
     const fakeProvider = EmberObject.create({
         reviewableStatusCounts: {
             pending: 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,41 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/core@^7.1.6":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.3.4.tgz#921a5a13746c21e32445bf0798680e9d11a6530b"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.3.4"
+    "@babel/helpers" "^7.2.0"
+    "@babel/parser" "^7.3.4"
+    "@babel/template" "^7.2.2"
+    "@babel/traverse" "^7.3.4"
+    "@babel/types" "^7.3.4"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.4.tgz#9aa48c1989257877a9d971296e5b73bfe72e446e"
+  dependencies:
+    "@babel/types" "^7.3.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
 "@babel/helper-function-name@7.0.0-beta.32":
   version "7.0.0-beta.32"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.32.tgz#6161af4419f1b4e3ed2d28c0c79c160e218be1f3"
@@ -18,11 +53,51 @@
     "@babel/template" "7.0.0-beta.32"
     "@babel/types" "7.0.0-beta.32"
 
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-get-function-arity@7.0.0-beta.32":
   version "7.0.0-beta.32"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.32.tgz#93721a99db3757de575a83bab7c453299abca568"
   dependencies:
     "@babel/types" "7.0.0-beta.32"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helpers@^7.2.0":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.3.1.tgz#949eec9ea4b45d3210feb7dc1c22db664c9e44b9"
+  dependencies:
+    "@babel/template" "^7.1.2"
+    "@babel/traverse" "^7.1.5"
+    "@babel/types" "^7.3.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.2.2", "@babel/parser@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
 
 "@babel/template@7.0.0-beta.32":
   version "7.0.0-beta.32"
@@ -32,6 +107,14 @@
     "@babel/types" "7.0.0-beta.32"
     babylon "7.0.0-beta.32"
     lodash "^4.2.0"
+
+"@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.2.2"
+    "@babel/types" "^7.2.2"
 
 "@babel/traverse@^7.0.0-beta.31":
   version "7.0.0-beta.32"
@@ -46,6 +129,20 @@
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+"@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6", "@babel/traverse@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.3.4.tgz#1330aab72234f8dea091b08c4f8b9d05c7119e06"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.3.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.3.4"
+    "@babel/types" "^7.3.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
 "@babel/types@7.0.0-beta.32", "@babel/types@^7.0.0-beta.31":
   version "7.0.0-beta.32"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.32.tgz#c317d0ecc89297b80bbcb2f50608e31f6452a5ff"
@@ -54,10 +151,17 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@0.23.0":
+"@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.4.tgz#bf482eaeaffb367a28abbf9357a94963235d90ed"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-03-13T20:56:09Z":
   version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/ember-osf/-/ember-osf-0.23.0.tgz#cceaa2768ec50a0abea5366e09b03a6979b17498"
-  integrity sha512-Bjlue4oVO2YcZP6F+JA2GzMHKRT8h4+IDtAAmH4dBdsI9uhapf1mHl9PbkCG0kC9rgjlWnJYGaj0K4sQ9bPKzQ==
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#a9791d5bdc84384cd0d0103e312fbc07f1863dd0"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
@@ -81,6 +185,7 @@
     ember-feature-flags "^5.0.0"
     ember-get-config "0.2.1"
     ember-i18n "5.0.1"
+    ember-in-viewport "^3.1.3"
     ember-metrics "https://github.com/cos-forks/ember-metrics#v0.12.1+cos0"
     ember-moment "^7.4.1"
     ember-power-select "^1.10.4"
@@ -96,6 +201,7 @@
     keen-tracking "1.1.3"
     langs "1.0.2"
     moment-timezone "^0.5.13"
+    node-sass "4.9.0"
     toastr "^2.1.2"
 
 "@centerforopenscience/eslint-config@^2.0.0":
@@ -111,7 +217,6 @@
 "@centerforopenscience/osf-style@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.9.0.tgz#0ab5cb17e2c531aafcc19e226f36ff86b734116e"
-  integrity sha512-R9IBVbz4eb/NkoM5TZGH46T9m5jspwK0H605O0oSMggHZPcTrf5gAHw0axeC26nKmEpz2FSXjvm84ziPNvhsvA==
 
 "@cos-forks/ember-content-placeholders@https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc":
   version "0.5.0"
@@ -194,6 +299,139 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
+"@webassemblyjs/ast@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
+  dependencies:
+    "@webassemblyjs/helper-module-context" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/wast-parser" "1.7.11"
+
+"@webassemblyjs/floating-point-hex-parser@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz#a69f0af6502eb9a3c045555b1a6129d3d3f2e313"
+
+"@webassemblyjs/helper-api-error@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz#c7b6bb8105f84039511a2b39ce494f193818a32a"
+
+"@webassemblyjs/helper-buffer@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz#3122d48dcc6c9456ed982debe16c8f37101df39b"
+
+"@webassemblyjs/helper-code-frame@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz#cf8f106e746662a0da29bdef635fcd3d1248364b"
+  dependencies:
+    "@webassemblyjs/wast-printer" "1.7.11"
+
+"@webassemblyjs/helper-fsm@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz#df38882a624080d03f7503f93e3f17ac5ac01181"
+
+"@webassemblyjs/helper-module-context@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz#d874d722e51e62ac202476935d649c802fa0e209"
+
+"@webassemblyjs/helper-wasm-bytecode@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz#dd9a1e817f1c2eb105b4cf1013093cb9f3c9cb06"
+
+"@webassemblyjs/helper-wasm-section@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz#9c9ac41ecf9fbcfffc96f6d2675e2de33811e68a"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-buffer" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/wasm-gen" "1.7.11"
+
+"@webassemblyjs/ieee754@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz#c95839eb63757a31880aaec7b6512d4191ac640b"
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.7.11.tgz#d7267a1ee9c4594fd3f7e37298818ec65687db63"
+  dependencies:
+    "@xtuc/long" "4.2.1"
+
+"@webassemblyjs/utf8@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.7.11.tgz#06d7218ea9fdc94a6793aa92208160db3d26ee82"
+
+"@webassemblyjs/wasm-edit@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz#8c74ca474d4f951d01dbae9bd70814ee22a82005"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-buffer" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/helper-wasm-section" "1.7.11"
+    "@webassemblyjs/wasm-gen" "1.7.11"
+    "@webassemblyjs/wasm-opt" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+    "@webassemblyjs/wast-printer" "1.7.11"
+
+"@webassemblyjs/wasm-gen@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz#9bbba942f22375686a6fb759afcd7ac9c45da1a8"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/ieee754" "1.7.11"
+    "@webassemblyjs/leb128" "1.7.11"
+    "@webassemblyjs/utf8" "1.7.11"
+
+"@webassemblyjs/wasm-opt@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz#b331e8e7cef8f8e2f007d42c3a36a0580a7d6ca7"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-buffer" "1.7.11"
+    "@webassemblyjs/wasm-gen" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+
+"@webassemblyjs/wasm-parser@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz#6e3d20fa6a3519f6b084ef9391ad58211efb0a1a"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-api-error" "1.7.11"
+    "@webassemblyjs/helper-wasm-bytecode" "1.7.11"
+    "@webassemblyjs/ieee754" "1.7.11"
+    "@webassemblyjs/leb128" "1.7.11"
+    "@webassemblyjs/utf8" "1.7.11"
+
+"@webassemblyjs/wast-parser@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz#25bd117562ca8c002720ff8116ef9072d9ca869c"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/floating-point-hex-parser" "1.7.11"
+    "@webassemblyjs/helper-api-error" "1.7.11"
+    "@webassemblyjs/helper-code-frame" "1.7.11"
+    "@webassemblyjs/helper-fsm" "1.7.11"
+    "@xtuc/long" "4.2.1"
+
+"@webassemblyjs/wast-printer@1.7.11":
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz#c4245b6de242cb50a2cc950174fdbf65c78d7813"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/wast-parser" "1.7.11"
+    "@xtuc/long" "4.2.1"
+
+"@xtuc/ieee754@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
+
+"@xtuc/long@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
+
 abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
@@ -216,6 +454,12 @@ ace-builds@^1.2.8:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.3.1.tgz#c7f9d7a657e7d9c630acd78f1dc2fa1e0e2a84f6"
 
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  dependencies:
+    acorn "^5.0.0"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -230,6 +474,10 @@ acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
+acorn@^5.0.0, acorn@^5.6.2:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+
 acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
@@ -238,6 +486,10 @@ after@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.1.tgz#ab5d4fb883f596816d3515f8f791c0af486dd627"
 
+ajv-errors@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
+
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -245,6 +497,10 @@ ajv-keywords@^1.0.0:
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+
+ajv-keywords@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
 
 ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
@@ -261,6 +517,15 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.1.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -285,6 +550,12 @@ amd-name-resolver@0.0.7:
 amd-name-resolver@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.0.0.tgz#0e593b28d6fa3326ab1798107edaea961046e8d8"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
+amd-name-resolver@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
   dependencies:
     ensure-posix-path "^1.0.1"
 
@@ -343,13 +614,20 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  dependencies:
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
+
 aot-test-generators@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/aot-test-generators/-/aot-test-generators-0.1.0.tgz#43f0f615f97cb298d7919c1b0b4e6b7310b03cd0"
   dependencies:
     jsesc "^2.5.0"
 
-aproba@^1.0.3:
+aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
@@ -436,6 +714,14 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+asn1.js@^4.0.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -447,6 +733,12 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
+assert@^1.1.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  dependencies:
+    util "0.10.3"
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -480,7 +772,7 @@ async-disk-cache@^1.2.1:
     rsvp "^3.0.18"
     username-sync "1.0.1"
 
-async-each@^1.0.0:
+async-each@^1.0.0, async-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
@@ -504,6 +796,12 @@ async@^2.4.1:
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
+
+async@^2.5.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
+  dependencies:
+    lodash "^4.17.11"
 
 async@~0.2.9:
   version "0.2.10"
@@ -644,6 +942,30 @@ babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
 
 babel-eslint@^7.2.3:
   version "7.2.3"
@@ -803,6 +1125,12 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.2.0-beta.6:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-ember-legacy-class-constructor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-legacy-class-constructor/-/babel-plugin-ember-legacy-class-constructor-0.1.4.tgz#dfe715b9bdb66f6c7e9eccc620137c03b3fa89e0"
@@ -818,6 +1146,12 @@ babel-plugin-ember-modules-api-polyfill@^2.3.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
   dependencies:
     ember-rfc176-data "^0.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.7.0.tgz#dcd6a9999da0d47d8c9185362bda6244ca525f4a"
+  dependencies:
+    ember-rfc176-data "^0.3.7"
 
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
@@ -895,6 +1229,10 @@ babel-plugin-syntax-class-properties@^6.8.0:
 babel-plugin-syntax-decorators@^6.1.18:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
@@ -1128,7 +1466,7 @@ babel-plugin-undefined-to-void@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz#7f578ef8b78dfae6003385d8417a61eda06e2f81"
 
-babel-polyfill@^6.16.0:
+babel-polyfill@^6.16.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -1168,6 +1506,41 @@ babel-preset-env@^1.5.1:
     babel-plugin-transform-exponentiation-operator "^6.22.0"
     babel-plugin-transform-regenerator "^6.22.0"
     browserslist "^2.1.2"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-preset-env@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
     invariant "^2.2.2"
     semver "^5.3.0"
 
@@ -1269,6 +1642,10 @@ base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
 
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+
 base64id@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-0.1.0.tgz#02ce0fdeee0cef4f40080e1e73e834f0b1bfce3f"
@@ -1303,6 +1680,10 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+
 binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
@@ -1332,6 +1713,14 @@ bluebird@^2.9.33:
 bluebird@^3.1.1, bluebird@^3.4.6:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
+bluebird@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
+
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
 body-parser@1.18.2, body-parser@^1.15.0:
   version "1.18.2"
@@ -1414,7 +1803,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.1:
+braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   dependencies:
@@ -1478,6 +1867,21 @@ broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.1.2:
     json-stable-stringify "^1.0.0"
     rsvp "^3.5.0"
     workerpool "^2.2.1"
+
+broccoli-babel-transpiler@^6.5.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz#a4afc8d3b59b441518eb9a07bd44149476e30738"
+  dependencies:
+    babel-core "^6.26.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-persistent-filter "^1.4.3"
+    clone "^2.0.0"
+    hash-for-dep "^1.2.3"
+    heimdalljs-logger "^0.1.7"
+    json-stable-stringify "^1.0.0"
+    rsvp "^4.8.2"
+    workerpool "^2.3.0"
 
 broccoli-brocfile-loader@^0.18.0:
   version "0.18.0"
@@ -1578,6 +1982,17 @@ broccoli-css-modules@^0.6.2:
 broccoli-debug@^0.6.1, broccoli-debug@^0.6.2, broccoli-debug@^0.6.3:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.4.tgz#986eb3d2005e00e3bb91f9d0a10ab137210cd150"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    symlink-or-copy "^1.1.8"
+    tree-sync "^1.2.2"
+
+broccoli-debug@^0.6.4:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.5.tgz#164a5cdafd8936e525e702bf8f91f39d758e2e78"
   dependencies:
     broccoli-plugin "^1.2.1"
     fs-tree-diff "^0.5.2"
@@ -1956,6 +2371,63 @@ broccoli@^1.1.0:
     tmp "0.0.31"
     underscore.string "^3.2.2"
 
+brorand@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+
+browserify-aes@^1.0.0, browserify-aes@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  dependencies:
+    buffer-xor "^1.0.3"
+    cipher-base "^1.0.0"
+    create-hash "^1.1.0"
+    evp_bytestokey "^1.0.3"
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
+browserify-cipher@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
+  dependencies:
+    browserify-aes "^1.0.4"
+    browserify-des "^1.0.0"
+    evp_bytestokey "^1.0.0"
+
+browserify-des@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
+  dependencies:
+    cipher-base "^1.0.1"
+    des.js "^1.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
+browserify-rsa@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
+  dependencies:
+    bn.js "^4.1.0"
+    randombytes "^2.0.1"
+
+browserify-sign@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.0.4.tgz#aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298"
+  dependencies:
+    bn.js "^4.1.1"
+    browserify-rsa "^4.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.2"
+    elliptic "^6.0.0"
+    inherits "^2.0.1"
+    parse-asn1 "^5.0.0"
+
+browserify-zlib@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  dependencies:
+    pako "~1.0.5"
+
 browserslist@^2.1.2, browserslist@^2.2.2:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.9.0.tgz#706aca15c53be15610f466e348cbfa0c00a6a379"
@@ -1970,7 +2442,7 @@ browserslist@^2.11.3:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
 
-browserslist@^3.2.8:
+browserslist@^3.2.6, browserslist@^3.2.8:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
   dependencies:
@@ -1991,9 +2463,29 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+
+buffer-xor@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+
+buffer@^4.3.0:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+builtin-status-codes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -2006,6 +2498,25 @@ bytes@1:
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+cacache@^11.0.2:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
+  dependencies:
+    bluebird "^3.5.3"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.3"
+    graceful-fs "^4.1.15"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.2"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -2214,6 +2725,41 @@ chokidar@1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chokidar@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.0"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+
+chrome-trace-event@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48"
+  dependencies:
+    tslib "^1.9.0"
+
+cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
@@ -2389,15 +2935,27 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+
 commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commander@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 common-tags@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
   dependencies:
     babel-runtime "^6.18.0"
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
 commoner@~0.10.3:
   version "0.10.8"
@@ -2459,6 +3017,15 @@ concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-stream@^1.5.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 config@1.26.1:
   version "1.26.1"
   resolved "https://registry.yarnpkg.com/config/-/config-1.26.1.tgz#f647ce32c345e80ba73a8eaa7a9a4b4e5b290ca1"
@@ -2486,6 +3053,12 @@ connect@^3.3.3:
     parseurl "~1.3.2"
     utils-merge "1.0.1"
 
+console-browserify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
+  dependencies:
+    date-now "^0.1.4"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -2504,6 +3077,10 @@ consolidate@^0.14.0:
   resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.14.5.tgz#5a25047bc76f73072667c8cb52c989888f494c63"
   dependencies:
     bluebird "^3.1.1"
+
+constants-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
 contains-path@^0.1.0:
   version "0.1.0"
@@ -2525,6 +3102,12 @@ convert-source-map@^1.1.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
+convert-source-map@^1.5.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  dependencies:
+    safe-buffer "~5.1.1"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -2532,6 +3115,17 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+copy-concurrently@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
+  dependencies:
+    aproba "^1.1.1"
+    fs-write-stream-atomic "^1.0.8"
+    iferr "^0.1.5"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.0"
 
 copy-dereference@^1.0.0:
   version "1.0.0"
@@ -2596,6 +3190,34 @@ coveralls@^3.0.0:
     minimist "^1.2.0"
     request "^2.79.0"
 
+create-ecdh@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
+  dependencies:
+    bn.js "^4.1.0"
+    elliptic "^6.0.0"
+
+create-hash@^1.1.0, create-hash@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -2627,6 +3249,22 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
+crypto-browserify@^3.11.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  dependencies:
+    browserify-cipher "^1.0.0"
+    browserify-sign "^4.0.0"
+    create-ecdh "^4.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.0"
+    diffie-hellman "^5.0.0"
+    inherits "^2.0.1"
+    pbkdf2 "^3.0.3"
+    public-encrypt "^4.0.0"
+    randombytes "^2.0.0"
+    randomfill "^1.0.3"
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -2649,6 +3287,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+cyclist@~0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -2665,6 +3307,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-now@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+
 debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -2677,7 +3323,7 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
+debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.4.0, debug@^2.6.8, debug@^2.6.9, debug@~2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2688,6 +3334,12 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
+
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  dependencies:
+    ms "^2.1.1"
 
 decamelize-keys@^1.0.0:
   version "1.1.0"
@@ -2703,6 +3355,10 @@ decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -2778,6 +3434,13 @@ depd@1.1.1, depd@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
+des.js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
+  dependencies:
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -2817,6 +3480,14 @@ diff@^3.1.0, diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
+diffie-hellman@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  dependencies:
+    bn.js "^4.1.0"
+    miller-rabin "^4.0.0"
+    randombytes "^2.0.0"
+
 dir-glob@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
@@ -2845,6 +3516,10 @@ dom-serializer@0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+domain-browser@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+
 domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
@@ -2872,6 +3547,15 @@ dot-prop@^4.1.0, dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+duplexify@^3.4.2, duplexify@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -2894,6 +3578,18 @@ electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47, electron-to-chromium
   version "1.3.59"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz#6377db04d8d3991d6286c72ed5c3fde6f4aaf112"
 
+elliptic@^6.0.0:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
 ember-ace@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-ace/-/ember-ace-1.3.1.tgz#b690cd1fe09a65a264dec40f9a54050af982a8da"
@@ -2911,6 +3607,35 @@ ember-assign-polyfill@^2.0.1:
   dependencies:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^2.0.0"
+
+ember-auto-import@^1.2.15:
+  version "1.2.21"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.21.tgz#e02ded183844faba66c3f2af97028ef35175b837"
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    babel-core "^6.26.3"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.26.0"
+    babylon "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-plugin "^1.3.0"
+    debug "^3.1.0"
+    ember-cli-babel "^6.6.0"
+    enhanced-resolve "^4.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^1.0.0"
+    handlebars "~4.0.13"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pkg-up "^2.0.0"
+    resolve "^1.7.1"
+    rimraf "^2.6.2"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.3"
+    webpack "~4.28"
 
 ember-basic-dropdown@^0.34.0:
   version "0.34.0"
@@ -3004,6 +3729,24 @@ ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.9.2:
     clone "^2.0.0"
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
+
+ember-cli-babel@^6.16.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
 
 ember-cli-bootstrap-sassy@^0.5.8:
   version "0.5.8"
@@ -3252,7 +3995,6 @@ ember-cli-qunit@^4.0.0:
 ember-cli-sass@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-sass/-/ember-cli-sass-7.2.0.tgz#293d1a94c43c1fdbb3835378e43d255e8ad5c961"
-  integrity sha512-X4BNBYuCyfRMGJ/Bjjk/gQw4eT6ixIXNltDQ8kapymilCqKEBZ6Rlx6noEfVzeh2nK7VP0e4rQ4DBj+TK6EDzA==
   dependencies:
     broccoli-funnel "^1.0.0"
     broccoli-merge-trees "^1.1.0"
@@ -3353,6 +4095,13 @@ ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-ve
 ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
+ember-cli-version-checker@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   dependencies:
     resolve "^1.3.3"
     semver "^5.3.0"
@@ -3725,6 +4474,15 @@ ember-i18n@5.0.2:
     ember-cli-version-checker "^1.2.0"
     ember-getowner-polyfill "^1.2.2"
 
+ember-in-viewport@^3.1.3:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/ember-in-viewport/-/ember-in-viewport-3.2.2.tgz#81110e04076cf693f29d19e58daf5a3a5b8da60e"
+  dependencies:
+    ember-auto-import "^1.2.15"
+    ember-cli-babel "^6.16.0"
+    intersection-observer-admin "0.0.5"
+    raf-pool "0.0.4"
+
 ember-inflector@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.1.0.tgz#afcb92d022a4eab58f08ff4578eafc3a1de2d09b"
@@ -3912,6 +4670,10 @@ ember-rfc176-data@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz#6a5a4b8b82ec3af34f3010965fa96b936ca94519"
 
+ember-rfc176-data@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.7.tgz#ecff7d74987d09296d3703343fed934515a4be33"
+
 ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
@@ -4081,6 +4843,10 @@ ember-wormhole@^0.5.2:
     ember-cli-babel "^6.0.0"
     ember-cli-htmlbars "^1.1.1"
 
+emojis-list@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
@@ -4090,6 +4856,12 @@ encoding@^0.1.11:
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
+
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  dependencies:
+    once "^1.4.0"
 
 engine.io-client@1.8.0:
   version "1.8.0"
@@ -4130,6 +4902,14 @@ engine.io@1.8.0:
     engine.io-parser "1.3.1"
     ws "1.1.1"
 
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.4.0"
+    tapable "^1.0.0"
+
 ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1, ensure-posix-path@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz#a65b3e42d0b71cfc585eb774f9943c8d9b91b0c2"
@@ -4137,6 +4917,12 @@ ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1, ensure-posix-path@^1.0.2:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+errno@^0.1.3, errno@~0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
+  dependencies:
+    prr "~1.0.1"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -4302,6 +5088,13 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.2.tgz#5f10cd6cabb1965bf479fa65745673439e21cb0e"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint@^2.7.0:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-2.13.1.tgz#e4cc8fa0f009fb829aaae23855a29360be1f6c11"
@@ -4452,6 +5245,17 @@ eventemitter3@1.x.x:
 events-to-array@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
+
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+
+evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  dependencies:
+    md5.js "^1.3.4"
+    safe-buffer "^5.1.1"
 
 exec-sh@^0.2.0:
   version "0.2.1"
@@ -4622,6 +5426,10 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
 fast-glob@^2.0.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.2.tgz#71723338ac9b4e0e2fff1d6748a2a13d5ed352bf"
@@ -4688,6 +5496,10 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
+
+figgy-pudding@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
 
 figures@^1.3.5:
   version "1.7.0"
@@ -4767,6 +5579,14 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+find-cache-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-index@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-1.1.0.tgz#53007c79cd30040d6816d79458e8837d5c5705ef"
@@ -4783,6 +5603,12 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
 
 findup-sync@0.4.3, findup-sync@^0.4.2:
   version "0.4.3"
@@ -4827,6 +5653,13 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flush-write-stream@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.3.6"
 
 font-awesome@^4.7.0:
   version "4.7.0"
@@ -4881,6 +5714,13 @@ fragment-cache@^0.2.1:
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+
+from2@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
 
 front-matter@2.1.2:
   version "2.1.2"
@@ -4952,6 +5792,20 @@ fs-extra@^4.0.0, fs-extra@^4.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  dependencies:
+    minipass "^2.2.1"
+
 fs-readdir-recursive@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
@@ -4959,6 +5813,15 @@ fs-readdir-recursive@^0.1.0:
 fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz#315e2b098d5fe7f622880ac965b1b051868ac871"
+  dependencies:
+    heimdalljs-logger "^0.1.7"
+    object-assign "^4.1.0"
+    path-posix "^1.0.0"
+    symlink-or-copy "^1.1.8"
+
+fs-tree-diff@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-1.0.2.tgz#0e2931733a85b55feb3472c0b89a20b0c03ac0de"
   dependencies:
     heimdalljs-logger "^0.1.7"
     object-assign "^4.1.0"
@@ -4975,6 +5838,15 @@ fs-updater@^1.0.4:
     heimdalljs-logger "^0.1.9"
     rimraf "^2.6.2"
 
+fs-write-stream-atomic@^1.0.8:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
+  dependencies:
+    graceful-fs "^4.1.2"
+    iferr "^0.1.5"
+    imurmurhash "^0.1.4"
+    readable-stream "1 || 2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -4985,6 +5857,13 @@ fsevents@^1.0.0:
   dependencies:
     nan "^2.3.0"
     node-pre-gyp "^0.6.39"
+
+fsevents@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
+  dependencies:
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -5150,6 +6029,17 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-modules@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
@@ -5169,6 +6059,10 @@ global-prefix@^0.1.4:
 globals@^10.0.0:
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-10.3.0.tgz#716aba93657b56630b5a0e77de5ea8ac6215afaa"
+
+globals@^11.1.0:
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
 
 globals@^6.4.0:
   version "6.4.1"
@@ -5246,6 +6140,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4,
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graceful-fs@^4.1.15:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
@@ -5263,6 +6161,16 @@ handlebars@^4.0.1, handlebars@^4.0.4, handlebars@^4.0.6:
     source-map "^0.4.4"
   optionalDependencies:
     uglify-js "^2.6"
+
+handlebars@~4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.13.tgz#89fc17bf26f46fd7f6f99d341d92efaae64f997d"
+  dependencies:
+    async "^2.5.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -5372,6 +6280,13 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+hash-base@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 hash-for-dep@^1.0.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.2.3.tgz#5ec69fca32c23523972d52acb5bb65ffc3664cab"
@@ -5381,9 +6296,27 @@ hash-for-dep@^1.0.2:
     heimdalljs-logger "^0.1.7"
     resolve "^1.4.0"
 
+hash-for-dep@^1.2.3:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.5.0.tgz#02dacb5a3ee14e45d06f5aa039d142c970940476"
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    heimdalljs "^0.2.3"
+    heimdalljs-logger "^0.1.7"
+    path-root "^0.1.1"
+    resolve "^1.10.0"
+    resolve-package-path "^1.0.11"
+
 hash-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hash-string/-/hash-string-1.0.0.tgz#c3fa15f078ddd16bc150b4176fde7091620f2c7f"
+
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
 
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
@@ -5436,6 +6369,14 @@ heimdalljs@^0.3.0:
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
   dependencies:
     rsvp "~3.2.1"
+
+hmac-drbg@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -5533,13 +6474,37 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
+iconv-lite@^0.4.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 icss-replace-symbols@^1.0.2, icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
+
+ieee754@^1.1.4:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+
+iferr@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  dependencies:
+    minimatch "^3.0.4"
 
 ignore@^3.1.2, ignore@^3.3.3:
   version "3.3.7"
@@ -5671,6 +6636,10 @@ inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+intersection-observer-admin@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/intersection-observer-admin/-/intersection-observer-admin-0.0.5.tgz#4a97796aab49c2bca2341fcd84cae2fea79c829b"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
@@ -6081,6 +7050,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@3.8.4, js-yaml@^3.6.1:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
@@ -6118,6 +7091,10 @@ jsesc@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+
 jsesc@~0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.3.0.tgz#1bf5ee63b4539fe2e26d0c1e99c240b97a457972"
@@ -6126,13 +7103,17 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-parse-better-errors@^1.0.1:
+json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -6163,6 +7144,18 @@ json5@0.4.0, json5@^0.4.0:
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
+
+json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  dependencies:
+    minimist "^1.2.0"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -6326,6 +7319,18 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
+loader-runner@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
+
+loader-utils@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^2.0.0"
+    json5 "^1.0.1"
+
 loader.js@^4.2.3:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.6.0.tgz#b965663ddbe2d80da482454cb865efe496e93e22"
@@ -6335,6 +7340,13 @@ locate-path@^2.0.0:
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
     p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 lodash-node@^2.4.1:
@@ -6735,6 +7747,10 @@ lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lo
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.10, lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
 log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
@@ -6787,11 +7803,24 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  dependencies:
+    yallist "^3.0.2"
+
 make-dir@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.1.0.tgz#19b4369fe48c116f53c2af95ad102c0e39e85d51"
   dependencies:
     pify "^3.0.0"
+
+make-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -6871,6 +7900,14 @@ md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
 md5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
@@ -6893,6 +7930,13 @@ mdurl@^1.0.1:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+memory-fs@^0.4.0, memory-fs@~0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
+  dependencies:
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
 
 memory-streams@^0.1.0:
   version "0.1.2"
@@ -6995,7 +8039,7 @@ micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.10:
+micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -7012,6 +8056,13 @@ micromatch@^3.1.10:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+miller-rabin@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  dependencies:
+    bn.js "^4.0.0"
+    brorand "^1.0.1"
 
 "mime-db@>= 1.30.0 < 2", mime-db@~1.30.0:
   version "1.30.0"
@@ -7030,6 +8081,14 @@ mime@1.4.1, mime@^1.2.11:
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+
+minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
@@ -7062,6 +8121,34 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minipass@^2.2.1, minipass@^2.3.4:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  dependencies:
+    minipass "^2.2.1"
+
+mississippi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
+  dependencies:
+    concat-stream "^1.5.0"
+    duplexify "^3.4.2"
+    end-of-stream "^1.1.0"
+    flush-write-stream "^1.0.0"
+    from2 "^2.1.0"
+    parallel-transform "^1.1.0"
+    pump "^3.0.0"
+    pumpify "^1.3.3"
+    stream-each "^1.1.0"
+    through2 "^2.0.0"
+
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
@@ -7069,7 +8156,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -7115,6 +8202,17 @@ mout@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mout/-/mout-1.1.0.tgz#0b29d41e6a80fa9e2d4a5be9d602e1d9d02177f6"
 
+move-concurrently@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
+  dependencies:
+    aproba "^1.1.1"
+    copy-concurrently "^1.0.0"
+    fs-write-stream-atomic "^1.0.8"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.3"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -7126,6 +8224,10 @@ ms@0.7.2:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 mustache@^2.2.1:
   version "2.3.0"
@@ -7142,6 +8244,10 @@ mute-stream@0.0.6:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+nan@^2.10.0, nan@^2.9.2:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
 
 nan@^2.3.0, nan@^2.3.2:
   version "2.7.0"
@@ -7178,9 +8284,21 @@ ncname@1.0.x:
   dependencies:
     xml-char-classes "^1.0.0"
 
+needle@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+neo-async@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -7227,6 +8345,34 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
+node-libs-browser@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"
+  dependencies:
+    assert "^1.1.1"
+    browserify-zlib "^0.2.0"
+    buffer "^4.3.0"
+    console-browserify "^1.1.0"
+    constants-browserify "^1.0.0"
+    crypto-browserify "^3.11.0"
+    domain-browser "^1.1.1"
+    events "^3.0.0"
+    https-browserify "^1.0.0"
+    os-browserify "^0.3.0"
+    path-browserify "0.0.0"
+    process "^0.11.10"
+    punycode "^1.2.4"
+    querystring-es3 "^0.2.0"
+    readable-stream "^2.3.3"
+    stream-browserify "^2.0.1"
+    stream-http "^2.7.2"
+    string_decoder "^1.0.0"
+    timers-browserify "^2.0.4"
+    tty-browserify "0.0.0"
+    url "^0.11.0"
+    util "^0.11.0"
+    vm-browserify "0.0.4"
+
 node-modules-path@^1.0.0, node-modules-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/node-modules-path/-/node-modules-path-1.0.1.tgz#40096b08ce7ad0ea14680863af449c7c75a5d1c8"
@@ -7239,6 +8385,21 @@ node-notifier@^5.0.1:
     semver "^5.3.0"
     shellwords "^0.1.0"
     which "^1.2.12"
+
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -7261,6 +8422,30 @@ node-releases@^1.0.0-alpha.11:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.0-alpha.11.tgz#73c810acc2e5b741a17ddfbb39dfca9ab9359d8a"
   dependencies:
     semver "^5.3.0"
+
+node-sass@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.0.tgz#d1b8aa855d98ed684d6848db929a20771cc2ae52"
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.clonedeep "^4.3.2"
+    lodash.mergewith "^4.6.0"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.10.0"
+    node-gyp "^3.3.1"
+    npmlog "^4.0.0"
+    request "~2.79.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
 
 node-sass@^4.1.0:
   version "4.6.1"
@@ -7331,11 +8516,15 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.0, normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
 
 normalize-range@^0.1.2:
   version "0.1.2"
@@ -7344,6 +8533,10 @@ normalize-range@^0.1.2:
 normalize-selector@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
+
+npm-bundled@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
 
 npm-git-info@^1.0.0:
   version "1.0.3"
@@ -7355,6 +8548,13 @@ npm-package-arg@^4.1.1:
   dependencies:
     hosted-git-info "^2.1.5"
     semver "^5.1.0"
+
+npm-packlist@^1.1.6:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -7436,7 +8636,7 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@1.x, once@^1.3.0, once@^1.3.3:
+once@1.x, once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -7483,6 +8683,10 @@ ora@^1.3.0:
     cli-spinners "^1.0.0"
     log-symbols "^1.0.2"
 
+os-browserify@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+
 os-homedir@1.0.2, os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -7524,11 +8728,27 @@ p-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
 
+p-limit@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 pagination-pager@^3.0.0:
   version "3.1.0"
@@ -7536,11 +8756,34 @@ pagination-pager@^3.0.0:
   dependencies:
     ember-cli-babel "^5.1.7"
 
+pako@~1.0.5:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+
+parallel-transform@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
+  dependencies:
+    cyclist "~0.2.2"
+    inherits "^2.0.3"
+    readable-stream "^2.1.5"
+
 param-case@2.1.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
   dependencies:
     no-case "^2.2.0"
+
+parse-asn1@^5.0.0:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.4.tgz#37f6628f823fbdeb2273b4d540434a22f3ef1fcc"
+  dependencies:
+    asn1.js "^4.0.0"
+    browserify-aes "^1.0.0"
+    create-hash "^1.1.0"
+    evp_bytestokey "^1.0.0"
+    pbkdf2 "^3.0.3"
+    safe-buffer "^5.1.1"
 
 parse-entities@^1.0.2, parse-entities@^1.1.0:
   version "1.1.2"
@@ -7611,6 +8854,10 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
+path-browserify@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -7645,9 +8892,23 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+
 path-posix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-posix/-/path-posix-1.0.0.tgz#06b26113f56beab042545a23bfa88003ccac260f"
+
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  dependencies:
+    path-root-regex "^0.1.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -7679,6 +8940,16 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+pbkdf2@^3.0.3:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -7695,6 +8966,10 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -7710,6 +8985,18 @@ pkg-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
   dependencies:
     find-up "^1.0.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  dependencies:
+    find-up "^2.1.0"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -7934,7 +9221,7 @@ printf@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
 
-private@^0.1.6, private@^0.1.7, private@~0.1.5:
+private@^0.1.6, private@^0.1.7, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -7942,11 +9229,19 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 process-relative-require@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/process-relative-require/-/process-relative-require-1.0.0.tgz#1590dfcf5b8f2983ba53e398446b68240b4cc68a"
   dependencies:
     node-modules-path "^1.0.0"
+
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
 progress@^1.1.8:
   version "1.1.8"
@@ -7955,6 +9250,10 @@ progress@^1.1.8:
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
+promise-inflight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
 promise-map-series@^0.2.1:
   version "0.2.3"
@@ -7969,13 +9268,58 @@ proxy-addr@~2.0.2:
     forwarded "~0.1.2"
     ipaddr.js "1.5.2"
 
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-punycode@^1.4.1:
+public-encrypt@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
+  dependencies:
+    bn.js "^4.1.0"
+    browserify-rsa "^4.0.0"
+    create-hash "^1.1.0"
+    parse-asn1 "^5.0.0"
+    randombytes "^2.0.1"
+    safe-buffer "^5.1.2"
+
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
+
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+
+punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 q@^1.1.2:
   version "1.5.1"
@@ -7992,6 +9336,14 @@ qs@~6.3.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+querystring-es3@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -8017,12 +9369,29 @@ qunit@^2.4.1:
     resolve "1.3.2"
     walk-sync "0.3.1"
 
+raf-pool@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/raf-pool/-/raf-pool-0.0.4.tgz#126ccaeeaa378e33c912f808a3c8f14acd0a714e"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  dependencies:
+    safe-buffer "^5.1.0"
+
+randomfill@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  dependencies:
+    randombytes "^2.0.5"
+    safe-buffer "^5.1.0"
 
 range-parser@~1.2.0:
   version "1.2.0"
@@ -8049,6 +9418,15 @@ rc@^1.1.7:
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
     deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  dependencies:
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -8098,6 +9476,18 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.1.5, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@^2, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
@@ -8127,6 +9517,14 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+readdirp@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
+  dependencies:
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    readable-stream "^2.0.2"
 
 readline2@^1.0.1:
   version "1.0.1"
@@ -8517,6 +9915,13 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
+resolve-package-path@^1.0.11:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-1.2.4.tgz#814c5fcfb5f6e4151d95ec6e5653707c43706670"
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.10.0"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -8536,6 +9941,12 @@ resolve@^1.1.2, resolve@^1.1.3, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, 
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.10.0, resolve@^1.3.2, resolve@^1.7.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
+  dependencies:
+    path-parse "^1.0.6"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -8570,6 +9981,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.
 rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
 
 rollup@^0.41.4:
   version "0.41.6"
@@ -8609,6 +10027,12 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-queue@^1.0.0, run-queue@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
+  dependencies:
+    aproba "^1.1.1"
+
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
@@ -8631,6 +10055,10 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+safe-buffer@^5.1.0, safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
 safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
@@ -8640,6 +10068,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
+
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 samsam@1.x, samsam@^1.1.3:
   version "1.3.0"
@@ -8685,6 +10117,25 @@ sass-lint@^1.11.1:
     path-is-absolute "^1.0.0"
     util "^0.10.3"
 
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+schema-utils@^0.4.4:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+
+schema-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-errors "^1.0.0"
+    ajv-keywords "^3.1.0"
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
@@ -8703,6 +10154,10 @@ select@^1.1.2:
 semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -8725,6 +10180,10 @@ send@0.16.1:
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.3.1"
+
+serialize-javascript@^1.4.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
 
 serve-static@1.13.1:
   version "1.13.1"
@@ -8761,6 +10220,10 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+setimmediate@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
@@ -8768,6 +10231,13 @@ setprototypeof@1.0.3:
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+
+sha.js@^2.4.0, sha.js@^2.4.8:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -8935,6 +10405,10 @@ sort-package-json@^1.4.0:
   dependencies:
     sort-object-keys "^1.1.1"
 
+source-list-map@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
@@ -8956,6 +10430,13 @@ source-map-support@^0.4.0, source-map-support@^0.4.15:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
+
+source-map-support@~0.5.10:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.11.tgz#efac2ce0800355d026326a0ca23e162aeac9a4e2"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-url@^0.3.0:
   version "0.3.0"
@@ -8981,7 +10462,11 @@ source-map@0.5.6, source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.6, source
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -9057,6 +10542,12 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+ssri@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+  dependencies:
+    figgy-pudding "^3.5.1"
+
 stable@~0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
@@ -9081,6 +10572,34 @@ stdout-stream@^1.4.0:
   resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
   dependencies:
     readable-stream "^2.0.1"
+
+stream-browserify@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
+  dependencies:
+    inherits "~2.0.1"
+    readable-stream "^2.0.2"
+
+stream-each@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
+  dependencies:
+    end-of-stream "^1.1.0"
+    stream-shift "^1.0.0"
+
+stream-http@^2.7.2:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.3.6"
+    to-arraybuffer "^1.0.0"
+    xtend "^4.0.0"
+
+stream-shift@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
 string-template@~0.2.1:
   version "0.2.1"
@@ -9109,9 +10628,21 @@ string_decoder@0.10, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
+string_decoder@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -9367,7 +10898,7 @@ symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz#cabe61e0010c1c023c173b25ee5108b37f4b4aa3"
 
-symlink-or-copy@^1.1.6:
+symlink-or-copy@^1.1.6, symlink-or-copy@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#5d49108e2ab824a34069b68974486c290020b393"
 
@@ -9402,6 +10933,10 @@ tap-parser@^5.1.0:
   optionalDependencies:
     readable-stream "^2"
 
+tapable@^1.0.0, tapable@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
+
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -9423,12 +10958,45 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tar@^4:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
 temp@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
   dependencies:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
+
+terser-webpack-plugin@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz#3f98bc902fac3e5d0de730869f50668561262ec8"
+  dependencies:
+    cacache "^11.0.2"
+    find-cache-dir "^2.0.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    terser "^3.16.1"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
+
+terser@^3.16.1:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
+  dependencies:
+    commander "^2.19.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.10"
 
 testem@^1.15.0, testem@^1.18.0:
   version "1.18.4"
@@ -9473,9 +11041,22 @@ text-table@~0.2.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.1.0.tgz#1be0dc2a0dc244d44be8a09af6a85afb93c4dbc3"
 
+through2@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
+
 through@^2.3.6, through@^2.3.8, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+timers-browserify@^2.0.4:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
+  dependencies:
+    setimmediate "^1.0.4"
 
 tiny-emitter@^2.0.0:
   version "2.0.2"
@@ -9523,6 +11104,10 @@ tmpl@1.0.x:
 to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+
+to-arraybuffer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
 to-fast-properties@^1.0.0, to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -9620,6 +11205,14 @@ tryor@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
 
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tty-browserify@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -9674,6 +11267,13 @@ uglify-js@^2.6, uglify-js@^2.7.0:
     yargs "~3.10.0"
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
+
+uglify-js@^3.1.4:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
@@ -9736,6 +11336,18 @@ uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
+unique-filename@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
+  dependencies:
+    unique-slug "^2.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.1.tgz#5e9edc6d1ce8fb264db18a507ef9bd8544451ca6"
+  dependencies:
+    imurmurhash "^0.1.4"
+
 unique-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
@@ -9795,13 +11407,30 @@ untildify@^2.1.0:
   dependencies:
     os-homedir "^1.0.0"
 
+upath@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
+
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  dependencies:
+    punycode "^2.1.0"
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 use@^3.1.0:
   version "3.1.0"
@@ -9831,11 +11460,17 @@ util-extend@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
 
-util@^0.10.3:
+util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
+
+util@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  dependencies:
+    inherits "2.0.3"
 
 utils-merge@1.0.1:
   version "1.0.1"
@@ -9889,6 +11524,12 @@ vfile@^2.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
+vm-browserify@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
+  dependencies:
+    indexof "0.0.1"
+
 walk-sync@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.1.tgz#558a16aeac8c0db59c028b73c66f397684ece465"
@@ -9914,6 +11555,13 @@ walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
+walk-sync@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.4.tgz#cf78486cc567d3a96b5b2237c6108017a5ffb9a4"
+  dependencies:
+    ensure-posix-path "^1.0.0"
+    matcher-collection "^1.0.0"
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -9923,6 +11571,50 @@ walker@~1.0.5:
 watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
+
+watchpack@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
+  dependencies:
+    chokidar "^2.0.2"
+    graceful-fs "^4.1.2"
+    neo-async "^2.5.0"
+
+webpack-sources@^1.1.0, webpack-sources@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
+
+webpack@~4.28:
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.28.4.tgz#1ddae6c89887d7efb752adf0c3cd32b9b07eacd0"
+  dependencies:
+    "@webassemblyjs/ast" "1.7.11"
+    "@webassemblyjs/helper-module-context" "1.7.11"
+    "@webassemblyjs/wasm-edit" "1.7.11"
+    "@webassemblyjs/wasm-parser" "1.7.11"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.1.0"
+    terser-webpack-plugin "^1.1.0"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
 
 websocket-driver@>=0.5.1:
   version "0.7.0"
@@ -9975,9 +11667,21 @@ wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
+worker-farm@^1.5.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
+  dependencies:
+    errno "~0.1.7"
+
 workerpool@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.0.tgz#86c5cbe946b55e7dc9d12b1936c8801a6e2d744d"
+  dependencies:
+    object-assign "4.1.1"
+
+workerpool@^2.3.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.3.tgz#49a70089bd55e890d68cc836a19419451d7c81d7"
   dependencies:
     object-assign "4.1.1"
 
@@ -10037,7 +11741,7 @@ xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
@@ -10045,9 +11749,17 @@ y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
+y18n@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
 
 yam@0.0.22:
   version "0.0.22"


### PR DESCRIPTION
## Purpose

This PR adds the functionality for preprint service moderators to see a list of withdrawal requests and to withdraw a preprint or to accept a withdrawal request (if there is one).

## Summary of Changes

- Notice entry for withdrawing a preprint is added to the action feed on the reviews index page.
  - The `action-feed-entry` component is modified.
- A new `Withdrawal Request` tab is added to allow moderators to see the list of withdrawal requests (the `withdrawals` view).
  - The `moderation-base` component is modified to add the `Withdrawal Request` tab to allow redirection to `withdrawals` view.
  - A new component `request-list-row` component is added to show each single withdrawal requests.
  - The `moderation-list` component is modified to use the newly added `request-list-row` component for showing withdrawal requests.
- The `preprint-detail` view is modified to allow moderators to accept/deny a withdrawal request, or to withdraw a published preprint directly when no withdrawal request exists. It is also changed to show a tombstone page for withdrawn preprints.
  - In `preprint-detail.js`,  `submitDecision()` is removed. Instead, two new actions `submitReviewsDecision()` and `submitRequestsDecision()` is added to handle the decision of two different types.
    - `submitReviewsDecision()` is the same as `submitDecison()`.
    - `submitRequestsDecision()` will make a new `preprint-request-action` instance.
  - The `preprint-status-banner` component is changed to take both the `submitReviewsDecision()` and `submitRequestsDecision()` actions so that moderators can submit differernt decisions depending on whether there is a withdrawal request attached to the current preprint.
- Miscellaneous CSS file and translation string file changes.

## Testing Notes

For pre-moderation:
![pre-moderation](https://user-images.githubusercontent.com/1566880/45371494-c5168f00-b5b8-11e8-8dec-10455df5abe4.png)

For post-moderation:
![post-moderation](https://user-images.githubusercontent.com/1566880/45371526-d65f9b80-b5b8-11e8-9f7d-3f0c6070a8e9.png)

Be sure to test all possible state transitions as shown in the sketch above. Note that most state transtions are unidirectional execept for that between `Accepted` and `Rejected` for pre-moderated preprints.

## Ticket

https://openscience.atlassian.net/browse/IN-327
https://openscience.atlassian.net/browse/IN-329



# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
