### PR TITLE
[Hotfix][Reviews][No Ticket] Add relevant date

### DIFF
--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -60,6 +60,8 @@ export default Controller.extend({
             DATE_LABEL.created;
     }),
 
+    relevantDate: computed.alias('preprint.dateCreated'),
+
     hasShortenedDescription: computed('preprint.description', function() {
         const preprintDescription = this.get('preprint.description');
 


### PR DESCRIPTION
## Purpose

Right now, `preprint-detail.hbs` uses a `relevantDate` property on the controller. But the `relevantDate` property does not exist on the controller. This is some bad copy pasta when moving the preprint detail page header from Preprints app to the Reviews app.
This PR fixes the problem by adding a `relevantDate` property on the controller and set it to the `dateCreated` of the preprint model.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
