### PR TITLE
[EMB-411] handle django csrf endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- add service:current-user to unit test needs for:
+  - moderation-list-row component unit test
+  - moderator-list-row component unit test
+  - preprint-status-banner component unit test
+  - preprints/provider/setup controller unit test
 
 ## [0.8.1] - 2018-12-13
 ### Changed

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "use-ember-osf-next-interfaces": "yarn upgrade @centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#release/next-interfaces#$(date -u +%FT%TZ)"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "0.22.1",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-02-04T16:55:50Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.8.0",
     "@cos-forks/ember-content-placeholders": "https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc",

--- a/testem.js
+++ b/testem.js
@@ -1,8 +1,12 @@
 /* eslint-env node */
+
+const DotReporter = require('testem/lib/reporters/dot_reporter');
+
 module.exports = {
     framework: 'qunit',
     test_page: 'tests/index.html?hidepassed',
     disable_watching: true,
+    reporter: new DotReporter(),
     launch_in_ci: [
         'Chrome',
         'Firefox',

--- a/tests/unit/components/moderation-list-row-test.js
+++ b/tests/unit/components/moderation-list-row-test.js
@@ -10,6 +10,7 @@ moduleForComponent('moderation-list-row', 'Unit | Component | moderation list ro
         'model:user',
         'model:preprint',
         'model:preprint-provider',
+        'service:current-user',
         'service:i18n',
         'service:theme',
     ],

--- a/tests/unit/components/moderator-list-row-test.js
+++ b/tests/unit/components/moderator-list-row-test.js
@@ -9,6 +9,7 @@ moduleForComponent('moderator-list-row', 'Unit | Component | moderator list row'
     unit: true,
     needs: [
         'model:user',
+        'service:current-user',
         'service:i18n',
         'service:metrics',
     ],

--- a/tests/unit/components/preprint-status-banner-test.js
+++ b/tests/unit/components/preprint-status-banner-test.js
@@ -14,6 +14,7 @@ moduleForComponent('preprint-status-banner', 'Unit | Component | preprint status
         'model:user',
         'model:preprint',
         'model:preprint-provider',
+        'service:current-user',
         'service:i18n',
         'service:theme',
     ],

--- a/tests/unit/controllers/preprints/provider/setup-test.js
+++ b/tests/unit/controllers/preprints/provider/setup-test.js
@@ -22,6 +22,7 @@ const i18nStub = EmberService.extend({
 moduleFor('controller:preprints/provider/setup', 'Unit | Controller | preprints/provider/setup', {
     needs: [
         'model:preprint-provider',
+        'service:current-user',
         'service:i18n',
         'service:metrics',
         'service:toast',

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,10 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@0.22.1":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-02-04T16:55:50Z":
   version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/ember-osf/-/ember-osf-0.22.1.tgz#6b2fe2d3aef2863a6c6005bc3218e5c32daa324a"
-  integrity sha512-e2DCaNJppm5ps0V9HlIwaWW0kxqhl1H1wNysasqzjFs3Bn6kurM7hRWcxz7KI8+wr1HBWPimOLfBW8defZv9bw==
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#c5476c85de99c71fdf40ec9e49e69575328f470c"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
@@ -75,6 +74,7 @@
     ember-component-css "^0.6.0"
     ember-computed-style "^0.2.0"
     ember-concurrency "^0.8.12"
+    ember-cookies "^0.3.1"
     ember-cp-validations "^3.5.0"
     ember-diff-attrs "^0.2.0"
     ember-feature-flags "^5.0.0"
@@ -3504,6 +3504,14 @@ ember-cookies@^0.0.13:
     ember-cli-babel "^5.1.7"
     ember-getowner-polyfill "^1.2.2"
 
+ember-cookies@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.3.1.tgz#42ca530703092f6cde691103d608a6a5a58f2d76"
+  integrity sha1-QspTBwMJL2zeaRED1gimpaWPLXY=
+  dependencies:
+    ember-cli-babel "^6.8.2"
+    ember-getowner-polyfill "^1.1.0 || ^2.0.0"
+
 ember-cp-validations@^3.5.0, ember-cp-validations@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ember-cp-validations/-/ember-cp-validations-3.5.2.tgz#1b205891ae7d7026f7b6c55cf6e440122db9b2ac"
@@ -3685,19 +3693,19 @@ ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.2.2:
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 
+"ember-getowner-polyfill@^1.1.0 || ^2.0.0", ember-getowner-polyfill@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+    ember-factory-for-polyfill "^1.3.1"
+
 ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
   dependencies:
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
-
-ember-getowner-polyfill@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    ember-factory-for-polyfill "^1.3.1"
 
 ember-i18n@5.0.1:
   version "5.0.1"
@@ -3763,16 +3771,6 @@ ember-maybe-import-regenerator@^0.1.5:
     broccoli-merge-trees "^1.0.0"
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
-
-"ember-metrics@git+https://github.com/cos-forks/ember-metrics.git#v0.12.1+cos0":
-  version "0.12.1"
-  uid "32fcc6eec0c4bc1974c854435401f94f660c6e74"
-  resolved "git+https://github.com/cos-forks/ember-metrics.git#32fcc6eec0c4bc1974c854435401f94f660c6e74"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    ember-cli-babel "^6.1.0"
-    ember-getowner-polyfill "^2.0.0"
-    ember-runtime-enumerable-includes-polyfill "^2.0.0"
 
 "ember-metrics@https://github.com/cos-forks/ember-metrics#v0.12.1+cos0":
   version "0.12.1"


### PR DESCRIPTION
## Purpose

This updates reviews to use the latest ember-osf, which includes the ability to handle CSRF tokens. It fixes tests that fail because they now need the current-user service.

## Summary of Changes/Side Effects

- Updated to ember-osf@develop
- add service:current-user to unit test needs for:
  - moderation-list-row component unit test
  - moderator-list-row component unit test
  - preprint-status-banner component unit test
  - preprints/provider/setup controller unit test

## Testing Notes

Need to make sure Reviews basic functionality still works after enabling the enforce_csrf waffle switch.

## Ticket

https://openscience.atlassian.net/browse/EMB-411

## Notes for Reviewer

I've tested locally with CSRF enabled and everything appears to be functional.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
