### PR TITLE
[EMB-413] add missing relevantDate alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - moderator-list-row component unit test
   - preprint-status-banner component unit test
   - preprints/provider/setup controller unit test
+- add missing `relevantDate` alias to preprints/provider/preprint-detail controller
 
 ## [0.8.1] - 2018-12-13
 ### Changed

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -40,6 +40,8 @@ export default Controller.extend({
     hasTags: bool('preprint.tags.length'),
     expandedAbstract: navigator.userAgent.includes('Prerender'),
 
+    relevantDate: computed.alias('preprint.dateCreated'),
+
     dummyMetaData: computed(function() {
         return new Array(7);
     }),


### PR DESCRIPTION
## Purpose

The date displayed for "CREATED ON"" was always the current date due to a missing controller property.

## Summary of Changes/Side Effects

- add missing `relevantDate` alias to preprints/provider/preprint-detail controller

## Testing Notes

Make sure "CREATED ON" date is the submission date and not today's date or the acceptance date.


## Ticket

https://openscience.atlassian.net/browse/EMB-413

## Notes for Reviewer

The property was just missing before so was reverting to current date.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
