### PR TITLE
chore: update osf-style to resolve from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-02-27T17:50:28Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
-    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style.git#develop#2019-02-27T19:13:37Z",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style.git#develop#2019-03-04T16:51:19Z",
     "@cos-forks/ember-content-placeholders": "https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc",
     "autoprefixer": "^9.1.2",
     "bootstrap-sass": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,9 +107,9 @@
     eslint-plugin-eslint-comments "^1.0.0"
     eslint-plugin-import "^2.7.0"
 
-"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style.git#develop#2019-02-27T19:13:37Z":
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style.git#develop#2019-03-04T16:51:19Z":
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.8.0.tgz#adde9771ec09d930b408a39a121ff10b925f2fd5"
+  resolved "https://github.com/CenterForOpenScience/osf-style.git#b1d529aeddf9fe47c1cdf18554ad634b1b5cd9a2"
 
 "@cos-forks/ember-content-placeholders@https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc":
   version "0.5.0"


### PR DESCRIPTION
## Purpose

Fix resolution of osf-style (should be currently resolving to github, not yarn registry.

## Summary of Changes/Side Effects

`yarn upgrade @centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style.git#develop#$(date -u +%FT%TZ)`

## Testing Notes

n/a

## Ticket

n/a

## Notes for Reviewer

See the `yarn.lock` diff

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
