### PR TITLE
[EMB-585] Hotfix/0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2019-03-11
+### Fixed
+- pass all links instead of just download link to file-renderer component
+
 ## [0.9.0] - 2019-03-04
 ### Changed
 - return to pending list after moderation

--- a/app/components/preprint-file-browser/template.hbs
+++ b/app/components/preprint-file-browser/template.hbs
@@ -1,4 +1,4 @@
-{{#file-renderer download=primaryFile.links.download
+{{#file-renderer links=primaryFile.links
     width="99%" height="700"}}
 {{/file-renderer}}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reviews",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Center for Open Science Reviews Service",
   "license": "Apache-2.0",
   "author": "",


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Rendering of preprint files is current broken on prod.

## Summary of Changes/Side Effects

Updated the invocation of the `file-renderer` component to pass `links=primaryFile.links` as was changed in ember-osf for preprints (see: https://github.com/CenterForOpenScience/ember-osf/pull/423).

## Testing Notes

Need to make sure preprint files now render.

## Ticket

https://openscience.atlassian.net/browse/EMB-585

## Notes for Reviewer

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
