### PR TITLE
[ENG-431] Withdrawal request date is incorrect on the preprint status banner.

### DIFF
--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -23,7 +23,7 @@
                     <a href={{creatorProfile}}>{{creatorName}}</a> {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format labelDate "MMMM DD, YYYY"}}
                     {{#if isPendingWithdrawal}}
                         <br>
-                        <a href={{withdrawalRequesterProfile}}>{{withdrawalRequesterName}}</a> {{t requestActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
+                        <a href={{withdrawalRequesterProfile}}>{{withdrawalRequesterName}}</a> {{t requestActivityLanguage documentType=submission.provider.documentType}} {{moment-format withdrawalRequest.dateLastTransitioned "MMMM DD, YYYY"}}
                     {{/if}}
                 {{/if}}
             {{/if}}


### PR DESCRIPTION
## Purpose and Changes
Use `withdrawalRequest.dateLastTransitioned`.

## Ticket

https://openscience.atlassian.net/browse/ENG-431

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
