### PR TITLE
[ENG-553] Remove node fetching.

### DIFF
--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -176,11 +176,6 @@ export default Controller.extend({
             this.set('isWithdrawn', true);
         }
         this.set('authors', response.get('contributors'));
-        const node = yield response.get('node');
-        if (node && !node.get('public')) {
-            this.transitionToRoute('page-not-found');
-            return;
-        }
         this.set('preprint', response);
         let withdrawalRequest = yield this.get('preprint.requests');
         withdrawalRequest = withdrawalRequest.toArray();


### PR DESCRIPTION
## Purpose

Currently, if a preprint has a non-public supplementary node, reviews app would stop fetching some data (e.g. withdrawal requests), causing the app to not show the withdrawal status banner. This PR fixes this problem by removing calls to fetch supplementary node, because we don't really need it.

## Ticket

https://openscience.atlassian.net/browse/ENG-553

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
