### PR TITLE
[Hotfix][No Ticket] Hotfix preprint-status-banner

### DIFF
--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -21,10 +21,10 @@
                     {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format submission.dateLastTransitioned "MMMM DD, YYYY"}}
                 {{else}}
                     <a href={{creatorProfile}}>{{creatorName}}</a> {{t recentActivityLanguage documentType=submission.provider.documentType}} {{moment-format labelDate "MMMM DD, YYYY"}}
-                    {{#if isPendingWithdrawal}}
-                        <br>
-                        <a href={{withdrawalRequesterProfile}}>{{withdrawalRequesterName}}</a> {{t requestActivityLanguage documentType=submission.provider.documentType}} {{moment-format withdrawalRequest.dateLastTransitioned "MMMM DD, YYYY"}}
-                    {{/if}}
+                {{/if}}
+                {{#if isPendingWithdrawal}}
+                    <br>
+                    <a href={{withdrawalRequesterProfile}}>{{withdrawalRequesterName}}</a> {{t requestActivityLanguage documentType=submission.provider.documentType}} {{moment-format withdrawalRequest.dateLastTransitioned "MMMM DD, YYYY"}}
                 {{/if}}
             {{/if}}
         </div>


### PR DESCRIPTION
## Purpose

Currently, if `noActions` is true and the preprint has a withdrawal request, the `preprint-status-banner` doesn't show the language for withdrawal request. This PR fixes the problem.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
