### PR TITLE
[ENG-559] Add withdrawal request denial reason

### DIFF
--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -112,6 +112,9 @@ const RequestDecisionJustificationValidation = buildValidations({
         description: 'Request decision justification',
         validators: [
             validator('presence', true),
+            validator('length', {
+                min: 20,
+            }),
         ],
         disabled: false,
     },

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import { validator, buildValidations } from 'ember-cp-validations';
 import latestAction from 'reviews/utils/latest-action';
 
 const PENDING = 'pending';
@@ -106,7 +107,17 @@ const RECENT_ACTIVITY = {
     },
 };
 
-export default Component.extend({
+const RequestDecisionJustificationValidation = buildValidations({
+    requestDecisionJustification: {
+        description: 'Request decision justification',
+        validators: [
+            validator('presence', true),
+        ],
+        disabled: false,
+    },
+});
+
+export default Component.extend(RequestDecisionJustificationValidation, {
     i18n: service(),
     theme: service(),
 
@@ -131,7 +142,8 @@ export default Component.extend({
     reviewerComment: '',
     decision: ACCEPTED,
     decisionValueToggled: false,
-    withdrawalJustification: alias('withdrawalRequest.comment'),
+    requestDecisionJustification: '',
+    didValidate: false,
 
     reviewsWorkflow: alias('submission.provider.reviewsWorkflow'),
     reviewsCommentsPrivate: alias('submission.provider.reviewsCommentsPrivate'),
@@ -327,6 +339,7 @@ export default Component.extend({
     }),
 
     didInsertElement() {
+        this.set('requestDecisionJustification', this.get('withdrawalRequest.comment'));
         this.get('submission.reviewActions')
             .then(latestAction)
             .then(this._handleActions.bind(this));
@@ -367,8 +380,14 @@ export default Component.extend({
             }
 
             let comment = '';
-            if (trigger === 'accept' && this.get('isPendingWithdrawal')) {
-                comment = this.get('withdrawalJustification').trim();
+            if (this.get('isPendingWithdrawal')) {
+                comment = this.get('requestDecisionJustification').trim();
+                if (trigger === 'reject') {
+                    this.set('didValidate', true);
+                    if (!this.get('validations.isValid')) {
+                        return;
+                    }
+                }
             } else {
                 comment = this.get('reviewerComment').trim();
             }
@@ -386,6 +405,12 @@ export default Component.extend({
         },
         decisionToggled() {
             this.get('setUserEnteredReview')(this.get('decisionChanged'));
+            if (this.get('isPendingWithdrawal') && this.get('decision') === ACCEPTED) {
+                this.set('requestDecisionJustification', this.get('withdrawalRequest.comment'));
+                this.set('validations.disabled', true);
+            } else if (this.get('isPendingWithdrawal') && this.get('decision') === REJECTED) {
+                this.set('requestDecisionJustification', '');
+            }
         },
         commentChanged() {
             this.get('setUserEnteredReview')(this.get('commentEdited'));

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -58,18 +58,25 @@
                                         <p>{{t declineExplanation}}</p>
                                     </span>
                                 </label>
-                                {{#if (eq decision 'accepted')}}
-                                    <label local-class="withdrawal-justification">
+                                <label local-class="withdrawal-justification">
+                                    {{#if (eq decision 'accepted')}}
                                         <span class="p-l-sm">
                                             {{t 'components.preprintStatusBanner.withdrawalJustification'}}
                                         </span>
-                                    </label>
-                                    {{textarea
-                                        value=withdrawalJustification
-                                        rows="8"
-                                        class="form-control"
-                                    }}
-                                {{/if}}
+                                    {{/if}}
+                                    {{#if (eq decision 'rejected')}}
+                                        <span class="p-l-sm">
+                                            {{t 'components.preprintStatusBanner.denialJustification'}}
+                                        </span>
+                                    {{/if}}
+                                </label>
+                                {{validated-input
+                                    inputType='textarea'
+                                    model=this
+                                    valuePath='requestDecisionJustification'
+                                    rows='8'
+                                    showErrorMessage=(and didValidate (eq decision 'rejected'))
+                                }}
                             </form>
                         </div>
                         <div local-class="feedback-footer">

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -282,6 +282,7 @@ export default {
                 withdrawn: 'not publicly available',
             },
             withdrawalJustification: 'Reason for withdrawal (optional, will be publicly displayed)',
+            denialJustification: 'Reason for denial (required, not publicly visible)',
             pending: 'pending',
             accepted: 'accepted',
             rejected: 'rejected',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "use-ember-osf-next-interfaces": "yarn upgrade @centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#release/next-interfaces#$(date -u +%FT%TZ)"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#0.24.0",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-07-17T15:42:04Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.9.0",
     "@cos-forks/ember-content-placeholders": "https://github.com/cos-forks/ember-content-placeholders#c85cdbeb4b9c206c3f76a92422db76815b2c95bc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,9 +159,9 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#0.24.0":
-  version "0.24.0"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#897bb9f77409f0f77d55ba3d17895b4ea5c01007"
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-07-17T15:42:04Z":
+  version "0.24.3"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#01fdcef8c4710212a8c047c7122f26464fb296ad"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

Enable moderators to add withdrawal request denial reason (mandatory) if they are to reject a withdrawal request.

## Summary of Changes/Side Effects

Change to use `validated-input` component for comment. Add validations.

## Testing Notes

Moderators can now add comments to withdrawal denials. Make sure those comments are required and properly surfaced to users on Preprints app.

## Ticket

https://openscience.atlassian.net/browse/ENG-559

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
