### PR TITLE
[no ticket] add isWithdrawn and version custom dimensions

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -57,6 +57,8 @@ module.exports = function(environment) {
                     authenticated: 'dimension1',
                     resource: 'dimension2',
                     isPublic: 'dimension3',
+                    isWithdrawn: 'dimension4',
+                    version: 'dimension5',
                 },
             },
         ],


### PR DESCRIPTION
## Purpose

We've added `version` as custom dimension 5 to ember-osf-web and need to add it here as a placeholder. `isWithdrawn` was already present in preprints as dimension 4.

## Summary of Changes/Side Effects

- add `isWithdrawn` as google analytics custom dimension 4
- add `version` as google analytics custom dimension 5

## Testing Notes

n/a

## Ticket

n/a

## Notes for Reviewer

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
