### PR TITLE
[ENG-2227] Load all authors for moderator preprint detail page

### DIFF
--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 import { task, waitForQueue } from 'ember-concurrency';
+import loadAll from 'ember-osf/utils/load-relationship';
 import $ from 'jquery';
 
 
@@ -38,6 +39,7 @@ export default Controller.extend({
     userHasEnteredReview: false,
     showWarning: false,
     previousTransition: null,
+    authors: [],
 
     hasTags: bool('preprint.tags.length'),
     expandedAbstract: navigator.userAgent.includes('Prerender'),
@@ -168,14 +170,17 @@ export default Controller.extend({
         const response = yield this.get('store').findRecord(
             'preprint',
             preprintId,
-            { include: ['node', 'license', 'review_actions', 'contributors'] },
+            { include: ['node', 'license', 'review_actions'] },
         ).catch(() => this.replaceRoute('page-not-found'));
 
+        const contributors = this.get('authors');
+        loadAll(response, 'contributors', contributors, {
+            filter: { bibliographic: true },
+        });
         this.set('preprint', response);
         if (response.get('dateWithdrawn') !== null) {
             this.set('isWithdrawn', true);
         }
-        this.set('authors', response.get('contributors'));
         this.set('preprint', response);
         let withdrawalRequest = yield this.get('preprint.requests');
         withdrawalRequest = withdrawalRequest.toArray();

--- a/app/controllers/preprints/provider/preprint-detail.js
+++ b/app/controllers/preprints/provider/preprint-detail.js
@@ -39,7 +39,6 @@ export default Controller.extend({
     userHasEnteredReview: false,
     showWarning: false,
     previousTransition: null,
-    authors: [],
 
     hasTags: bool('preprint.tags.length'),
     expandedAbstract: navigator.userAgent.includes('Prerender'),
@@ -173,10 +172,11 @@ export default Controller.extend({
             { include: ['node', 'license', 'review_actions'] },
         ).catch(() => this.replaceRoute('page-not-found'));
 
-        const contributors = this.get('authors');
+        const contributors = [];
         loadAll(response, 'contributors', contributors, {
             filter: { bibliographic: true },
         });
+        this.set('authors', contributors);
         this.set('preprint', response);
         if (response.get('dateWithdrawn') !== null) {
             this.set('isWithdrawn', true);


### PR DESCRIPTION
## Purpose
- Allow more than 10 preprint authors to be shown to moderators on the preprint detail page


## Summary of Changes/Side Effects
- Explicitly fetch all contributors for a given preprint, instead of just the first 10 using `loadAll`
## Screenshot
Screenshot of contributor list on routes like `osf.io/reviews/preprints/<provider_id>/<preprint_id>`
![Screen Shot 2021-04-08 at 11 03 17 AM](https://user-images.githubusercontent.com/51409893/114050168-09926600-985a-11eb-804c-16af02c98db2.png)


## Testing Notes
- This fix pertains to the reviews app, so make sure sure you are looking at the preprint detail page as a moderator, and not as a preprint author!
- Please ensure that a moderator for a preprint provider can see all the contributors on a preprint if there are more than 10 contributors (Note: depending on the server's speed, it may show the first 10 initially, then quietly be loading the next 10, and so on)
- For preprints with less than 10 contributors, the behavior should be unchanged
## Ticket

https://openscience.atlassian.net/browse/ENG-2227

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
