### PR TITLE
[ENG-3324][ENG-3327][ENG-3330][ENG-3333] Darken colors on Dashboard for more contrast

### DIFF
--- a/app/components/action-feed-entry/styles.scss
+++ b/app/components/action-feed-entry/styles.scss
@@ -12,7 +12,7 @@
 .action-body { } /* stylelint-disable-line block-no-empty */
 
 .action-date {
-    color: $color-text-gray-light;
+    color: $color-text-gray-dark;
     font-size: 16px;
     margin-left: 30px;
 }

--- a/app/components/action-feed/styles.scss
+++ b/app/components/action-feed/styles.scss
@@ -4,5 +4,9 @@
     .see-more {
         height: 20px;
         padding-left: 45px;
+
+        a {
+            color: $color-link-dark;
+        }
     }
 }

--- a/app/styles/_global.scss
+++ b/app/styles/_global.scss
@@ -30,6 +30,10 @@ body > :global(.ember-view) {
     margin-top: 0;
     text-shadow: 0 1px 0 $color-white;
     width: 100%;
+    
+    a {
+        color: $color-link-dark;
+    }
 }
 
 .footer ul,

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -89,3 +89,5 @@ $color-state-warning-text: $state-warning-text;
 $color-state-warning-bg: $state-warning-bg;
 $color-state-danger-text: $state-danger-text;
 $color-state-danger-bg: $state-danger-bg;
+
+$color-link-dark: #22537c;


### PR DESCRIPTION
## Purpose
Darkens colors of various items on the Dashboard to increase contrast for better accessibility.


## Summary of Changes/Side Effects
1. Added a scss variable for dark link color
2. Used dark link color for See More link on the activity feed
3. Used dark link color on the footer for all the links
4. Used dark gray text for the date on the activity feed.

<img width="950" alt="Screen Shot 2021-11-02 at 10 09 15 AM" src="https://user-images.githubusercontent.com/6599111/139866197-7c99beef-a593-4d9d-9f75-d1218907b26b.png">

## Testing Notes
Only color changes, so verifying accessibility is achieved should do it.


## Tickets

https://openscience.atlassian.net/browse/ENG-3324
https://openscience.atlassian.net/browse/ENG-3327
https://openscience.atlassian.net/browse/ENG-3330
https://openscience.atlassian.net/browse/ENG-3333
