### PR TITLE
[ENG-3332] Add aria-label to 'remove moderator' button

### DIFF
--- a/app/components/moderator-list-row/template.hbs
+++ b/app/components/moderator-list-row/template.hbs
@@ -69,7 +69,13 @@
                             {{t 'components.moderatorList.adminDisabledMessage'}}
                         {{/bs-tooltip}}
                     {{/if}}
-                    <a role="button" local-class="remove-button" class="{{if disableRemove 'disabled'}}" {{action 'removeInitiated'}}>
+                    <a
+                        role="button"
+                        local-class="remove-button"
+                        class="{{if disableRemove 'disabled'}}"
+                        aria-label={{t 'components.moderatorList.removeButton'}}
+                        {{action 'removeInitiated'}}
+                    >
                         <i class="fa fa-times fa-lg "></i>
                     </a>
                 </div>

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -260,6 +260,7 @@ export default {
         moderatorList: {
             editDisabledMessage: 'Can only edit one moderator at a time',
             adminDisabledMessage: 'Must have one admin',
+            removeButton: 'Remove moderator',
         },
         preprintStatusBanner: {
             recentActivity: {


### PR DESCRIPTION
## Purpose
Increases accessibility on the moderator list by adding a label to the X button for removing moderators.


## Summary of Changes/Side Effects
1. Add translation string
2. Add aria label to button


## Testing Notes
This should only affect accessibility


## Ticket

https://openscience.atlassian.net/browse/ENG-3332