### PR TITLE
[ENG-3336] Darken gray notification page helper text for accessibility

### DIFF
--- a/app/components/notification-list/styles.scss
+++ b/app/components/notification-list/styles.scss
@@ -25,7 +25,7 @@
 
 .helper-text {
     padding-left: 20px;
-    color: $color-text-gray-light;
+    color: $color-text-gray-dark;
 }
 
 .notification-menu {


### PR DESCRIPTION
## Purpose
The helper text on the notification page was way too light, so this makes it properly contrasting with the background.

## Summary of Changes/Side Effects
1. Darkened the "To configure other…" text

<img width="639" alt="Screen Shot 2021-11-16 at 9 10 26 AM" src="https://user-images.githubusercontent.com/6599111/142001018-2c9a8ad6-5d78-48e2-87f9-9382c526a337.png">

## Testing Notes
Only accessibility testing needed 

## Ticket

https://openscience.atlassian.net/browse/ENG-3336
