### PR TITLE
[ENG-3339] A11y settings page

### DIFF
--- a/app/components/form-block/template.hbs
+++ b/app/components/form-block/template.hbs
@@ -1,7 +1,7 @@
 <header>
     <div class="section-header">
         <h4 class="f-w-md">{{title}}</h4>
-        <p class="text-muted text-smaller">{{description}}</p>
+        <p class="text-smaller">{{description}}</p>
     </div>
 </header>
 

--- a/app/styles/_util.scss
+++ b/app/styles/_util.scss
@@ -1,4 +1,4 @@
 .disabled {
-    opacity: 0.4;
+    opacity: 0.7;
     pointer-events: none;
 }


### PR DESCRIPTION
## Purpose
Increases contrast of disabled text on the settings page for better accessibility.


## Summary of Changes/Side Effects
1. Increase opacity of disabled form elements
2. Un-mute the description text

<img width="619" alt="Screen Shot 2021-11-16 at 10 09 28 AM" src="https://user-images.githubusercontent.com/6599111/142011421-f4ff35b4-806a-451b-b30b-5b510ba1e293.png">

## Testing Notes
Should just need accessibility testing.

## Ticket

https://openscience.atlassian.net/browse/ENG-3339
